### PR TITLE
FE_style/pharmlist 약국리스트 레이아웃 및 CSS 수정

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           //? 임시로 로그인 여부와 계정유형 할당 // isLogin= true | false // account=["User", "Pharm", "Admin"]
-          <Route path="/" element={<Layout isLogin={false} account="" />}>
+          <Route path="/" element={<Layout isLogin={true} account="User" />}>
             <Route path="/" element={<Home />} />
             <Route path="/sign_up" element={<SignUp />} />
             <Route path="/sign_out" element={<SignOut />} />

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -10,23 +10,23 @@ import Button from "../Ul/Button";
 interface Props {
   isModalUp: boolean;
   setIsModalUp: React.Dispatch<React.SetStateAction<boolean>>;
-  like:boolean;
-  setLike:React.Dispatch<React.SetStateAction<boolean>>;
+  like: boolean;
+  setLike: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function PharmDetail({ isModalUp, setIsModalUp, like, setLike}: Props) {
+export default function PharmDetail({ isModalUp, setIsModalUp, like, setLike }: Props) {
   const [isReviewFormShown, setIsReviewFormShown] = useState(false);
 
   return (
     <>
       <ModalBackDrop onClick={() => setIsModalUp(!isModalUp)}>
-        <ModalContainer onClick={(event)=>event.stopPropagation()}>
+        <ModalContainer onClick={(event) => event.stopPropagation()}>
           <InfoHeader>
             <InfoTitle>킹갓약국</InfoTitle>
             <PharmRank />
           </InfoHeader>
           <Constant>
-            <PharmInfo like={like} setLike={setLike}/>
+            <PharmInfo like={like} setLike={setLike} />
             <ReviewContainer>
               <ReviewTitle>리뷰</ReviewTitle>
               <Reviews>
@@ -61,6 +61,8 @@ const ModalBackDrop = styled.div`
   align-items: center;
   height: 100vh;
   width: 100vw;
+  top: 0;
+  left: 0;
   background-color: var(--modal-backdrop);
 `;
 const ModalContainer = styled.div`
@@ -69,6 +71,7 @@ const ModalContainer = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
+  top: 30px;
   height: 600px;
   width: 940px;
   background-color: var(--white);

--- a/front/src/Components/PharmList/PharmItem.tsx
+++ b/front/src/Components/PharmList/PharmItem.tsx
@@ -1,5 +1,91 @@
-import React from "react";
+import { useState } from "react";
+import styled from "styled-components";
+import Tag from "../Ul/Tag";
+import PharmRank from "../Ul/PharmRank";
+import PharmDetail from "../Modal/PharmDetail";
 
 export default function PharmItem() {
-  return <div></div>;
+  const [isModalUp, setIsModalUp] = useState(false);
+  const [like, setLike] = useState(false);
+  const heart: boolean = true;
+  return (
+    <PharmCard>
+      {isModalUp ? (
+        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+      ) : null}
+      <HeartPosition>
+        <HeartButton>
+          {heart ? (
+            <img className="heart_img" alt="heart" src="Images/Heart.png" />
+          ) : (
+            <img className="unheart_img" alt="unheart" src="Images/UnHeart.png" />
+          )}
+        </HeartButton>
+      </HeartPosition>
+      <img className="pharm_img" src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(!isModalUp)} />
+      <PharmTitleBox>
+        <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
+        <PharmRank />
+      </PharmTitleBox>
+      <TagContainer>
+        <Tag idx={0} />
+        <Tag idx={1} />
+        <Tag idx={2} />
+        <Tag idx={3} />
+      </TagContainer>
+    </PharmCard>
+  );
 }
+
+//약국카드
+const PharmCard = styled.div`
+  width: 25rem;
+  height: 25rem;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--black-100);
+  .pharm_img {
+    background-color: var(--black-200);
+    width: 23.75rem;
+    height: 15.625rem;
+    display: flex;
+    justify-content: center;
+    margin: 30px auto 20px auto;
+    border-radius: 10px;
+  }
+`;
+//하트 버튼!!
+const HeartPosition = styled.div`
+  position: relative;
+`;
+const HeartButton = styled.button`
+  all: unset;
+  cursor: pointer;
+
+  img {
+    position: absolute;
+    right: 1rem;
+    top: 2.5rem;
+  }
+`;
+
+//약국 타이틀
+const PharmTitleBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 0 15px;
+`;
+
+const PharmName = styled.div`
+  font-size: 1.56rem;
+  font-weight: bold;
+`;
+
+//태그전체
+const TagContainer = styled.div`
+  margin: 15px 0 10px 0;
+  padding: 0 15px;
+  & > * {
+    margin: 0 2px;
+  }
+`;

--- a/front/src/Components/PharmList/PharmItem.tsx
+++ b/front/src/Components/PharmList/PharmItem.tsx
@@ -7,22 +7,18 @@ import PharmDetail from "../Modal/PharmDetail";
 export default function PharmItem() {
   const [isModalUp, setIsModalUp] = useState(false);
   const [like, setLike] = useState(false);
-  const heart: boolean = true;
+
   return (
     <PharmCard>
       {isModalUp ? (
         <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
       ) : null}
-      <HeartPosition>
-        <HeartButton>
-          {heart ? (
-            <img className="heart_img" alt="heart" src="Images/Heart.png" />
-          ) : (
-            <img className="unheart_img" alt="unheart" src="Images/UnHeart.png" />
-          )}
-        </HeartButton>
-      </HeartPosition>
-      <img className="pharm_img" src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(!isModalUp)} />
+      <InfoImgContainer>
+        <Img src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(!isModalUp)} />
+        <LikeButton onClick={() => setLike(!like)}>
+          {like ? <img src="./Images/Heart.png" /> : <img src="./Images/UnHeart.png" />}
+        </LikeButton>
+      </InfoImgContainer>
       <PharmTitleBox>
         <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
         <PharmRank />
@@ -43,6 +39,7 @@ const PharmCard = styled.div`
   height: 25rem;
   display: flex;
   flex-direction: column;
+  margin-top: 35px;
   border-bottom: 1px solid var(--black-100);
   .pharm_img {
     background-color: var(--black-200);
@@ -54,18 +51,30 @@ const PharmCard = styled.div`
     border-radius: 10px;
   }
 `;
-//하트 버튼!!
-const HeartPosition = styled.div`
-  position: relative;
-`;
-const HeartButton = styled.button`
-  all: unset;
-  cursor: pointer;
 
-  img {
-    position: absolute;
-    right: 1rem;
-    top: 2.5rem;
+const InfoImgContainer = styled.div`
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 5px;
+  border-bottom: 1px solid var(--black-100);
+`;
+const Img = styled.img`
+  object-fit: cover;
+  width: 23.75rem;
+  height: 15.625rem;
+  border-radius: 5px;
+`;
+const LikeButton = styled.span`
+  position: absolute;
+  right: 36px;
+  top: 12px;
+  width: 20px;
+  @media (max-width: 768px) {
+    right: 60px;
+    top: 11px;
   }
 `;
 
@@ -73,10 +82,12 @@ const HeartButton = styled.button`
 const PharmTitleBox = styled.div`
   display: flex;
   justify-content: space-between;
+  margin-top: 15px;
   padding: 0 15px;
 `;
 
 const PharmName = styled.div`
+  cursor: pointer;
   font-size: 1.56rem;
   font-weight: bold;
 `;

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -12,14 +12,14 @@ import Textarea from "../Ul/Textarea";
 export default function PharmLists() {
   /* 조건부로 할려고 임의로 해놓은 것!
   나중에 데이터 넘어오면 바꿀것*/
-  const [isModalUp, setIsModalUp] = useState(false)
+  const [isModalUp, setIsModalUp] = useState(false);
   const [like, setLike] = useState(false);
 
   return (
     <Container>
-      {isModalUp ? <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp}
-      like={like} setLike={setLike}
-      /> : null}
+      {isModalUp ? (
+        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+      ) : null}
       <ContainerWrap>
         <SearchContainer>
           <div>
@@ -42,7 +42,7 @@ export default function PharmLists() {
         </PharmHeadContainer>
         <PharmCard>
           <HeartPosition>
-            <HeartButton onClick={()=>setLike(!like)}>
+            <HeartButton onClick={() => setLike(!like)}>
               {like ? (
                 <img className="heart_img" alt="heart" src="Images/Heart.png" />
               ) : (
@@ -50,9 +50,14 @@ export default function PharmLists() {
               )}
             </HeartButton>
           </HeartPosition>
-          <img className="pharm_img" src="./Images/random.png" alt="고심약국" onClick={()=>setIsModalUp(!isModalUp)}/>
+          <img
+            className="pharm_img"
+            src="./Images/random.png"
+            alt="고심약국"
+            onClick={() => setIsModalUp(!isModalUp)}
+          />
           <PharmTitleBox>
-            <PharmName  onClick={()=>setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
+            <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
             <PharmRank />
           </PharmTitleBox>
           <TagContainer>
@@ -64,7 +69,7 @@ export default function PharmLists() {
         </PharmCard>
         <PharmCard>
           <HeartPosition>
-            <HeartButton onClick={()=>setLike(!like)}>
+            <HeartButton onClick={() => setLike(!like)}>
               {like ? (
                 <img className="heart_img" alt="heart" src="Images/Heart.png" />
               ) : (
@@ -72,9 +77,14 @@ export default function PharmLists() {
               )}
             </HeartButton>
           </HeartPosition>
-          <img className="pharm_img" src="./Images/random.png" alt="고심약국" onClick={()=>setIsModalUp(!isModalUp)}/>
+          <img
+            className="pharm_img"
+            src="./Images/random.png"
+            alt="고심약국"
+            onClick={() => setIsModalUp(!isModalUp)}
+          />
           <PharmTitleBox>
-            <PharmName  onClick={()=>setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
+            <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
             <PharmRank />
           </PharmTitleBox>
           <TagContainer>

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -1,245 +1,195 @@
 //홈화면 옆에 약국 리스트
-import { useState } from "react";
 import styled from "styled-components";
 import { BsSearch } from "react-icons/bs";
-import Tag from "../Ul/Tag";
-import PharmRank from "../Ul/PharmRank";
-import PharmDetail from "../Modal/PharmDetail";
-import Input from "../Ul/Input";
-import Textarea from "../Ul/Textarea";
+import PharmItem from "./PharmItem";
 
 //데이터 들어오면 map으로 돌리기전에 하드코딩으로 두개해놨음
 export default function PharmLists() {
   /* 조건부로 할려고 임의로 해놓은 것!
   나중에 데이터 넘어오면 바꿀것*/
-  const [isModalUp, setIsModalUp] = useState(false);
-  const [like, setLike] = useState(false);
 
   return (
-    <Container>
-      {isModalUp ? (
-        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
-      ) : null}
+    <ListContainer>
       <ContainerWrap>
-        <SearchContainer>
-          <div>
-            <BsSearch className="searchIcon" />
-          </div>
-          <SearchInput placeholder="약국 검색.." />
-        </SearchContainer>
-        <PharmHeadContainer>
-          <div>
-            <Button>
-              <img className="ourpharm_img" alt="pharm" src="Images/OurPharmGo.png" />
-              <span className="ourpharm">우리 약국</span>
-            </Button>
-          </div>
-          <FilterButtons>
-            <FilterButton className="filter_close">가까운순</FilterButton>
-            <FilterButton className="filter_popular">리뷰많은순</FilterButton>
-            <FilterButton className="filter_star">별점높은순</FilterButton>
-          </FilterButtons>
-        </PharmHeadContainer>
-        <PharmCard>
-          <HeartPosition>
-            <HeartButton onClick={() => setLike(!like)}>
-              {like ? (
-                <img className="heart_img" alt="heart" src="Images/Heart.png" />
-              ) : (
-                <img className="unheart_img" alt="unheart" src="Images/UnHeart.png" />
-              )}
-            </HeartButton>
-          </HeartPosition>
-          <img
-            className="pharm_img"
-            src="./Images/random.png"
-            alt="고심약국"
-            onClick={() => setIsModalUp(!isModalUp)}
-          />
-          <PharmTitleBox>
-            <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
-            <PharmRank />
-          </PharmTitleBox>
-          <TagContainer>
-            <Tag idx={0} />
-            <Tag idx={1} />
-            <Tag idx={2} />
-            <Tag idx={3} />
-          </TagContainer>
-        </PharmCard>
-        <PharmCard>
-          <HeartPosition>
-            <HeartButton onClick={() => setLike(!like)}>
-              {like ? (
-                <img className="heart_img" alt="heart" src="Images/Heart.png" />
-              ) : (
-                <img className="unheart_img" alt="unheart" src="Images/UnHeart.png" />
-              )}
-            </HeartButton>
-          </HeartPosition>
-          <img
-            className="pharm_img"
-            src="./Images/random.png"
-            alt="고심약국"
-            onClick={() => setIsModalUp(!isModalUp)}
-          />
-          <PharmTitleBox>
-            <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
-            <PharmRank />
-          </PharmTitleBox>
-          <TagContainer>
-            <Tag idx={0} />
-            <Tag idx={1} />
-            <Tag idx={2} />
-            <Tag idx={3} />
-          </TagContainer>
-        </PharmCard>
+        <EmptyContainer>
+          <span className="partition" />
+        </EmptyContainer>
+        <PharmContainer>
+          <PharmHeadContainer>
+            <SearchContainer>
+              <div>
+                <BsSearch className="searchIcon" />
+              </div>
+              <SearchInput placeholder="약국 검색.." />
+            </SearchContainer>
+            <ButtonContainer>
+              <Button>
+                <img className="ourpharm_img" alt="pharm" src="Images/OurPharmGo.png" />
+                <span className="ourpharm">우리 약국</span>
+              </Button>
+              <FilterButtons>
+                <FilterButton>가까운순</FilterButton>
+                <span className="partition" />
+                <FilterButton>리뷰많은순</FilterButton>
+                <span className="partition" />
+                <FilterButton>별점높은순</FilterButton>
+              </FilterButtons>
+            </ButtonContainer>
+          </PharmHeadContainer>
+          <PharmItemContainer>
+            <PharmItem />
+            <PharmItem />
+            <PharmItem />
+            <PharmItem />
+            <PharmItem />
+          </PharmItemContainer>
+        </PharmContainer>
       </ContainerWrap>
-    </Container>
+    </ListContainer>
   );
 }
 
 //전체 컨테이너
-const Container = styled.div`
-  width: 37.5rem;
-  display: block;
-  position: relative;
+const ListContainer = styled.div`
+  width: 36rem;
+  height: calc(100vh - 50px);
+  border-top: 1px solid var(--black-150);
+  border-right: 1px solid var(--black-150);
+  border-bottom: 1px solid var(--black-150);
+  border-radius: 0 15px 15px 0;
   background-color: var(--white);
   box-shadow: var(--bs-lg);
+  padding: 1.5rem 0 1rem 1.5rem;
+  transition: 0.2s;
+  @media (max-width: 768px) {
+    transition: 0.2s;
+    width: 30rem;
+  }
 `;
-
 const ContainerWrap = styled.div`
-  display: list-item;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+`;
+const EmptyContainer = styled.div`
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-right: 36px;
+  .partition {
+    width: 14px;
+    border-radius: 7px;
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 4px inset, rgba(0, 0, 0, 0.1) 0px 7px 13px -3px inset,
+      rgba(0, 0, 0, 0.1) 0px -3px 0px, hsl(0, 0%, 100%, 0.1) 0 1px 0 0;
+    transition: 0.2s;
+    @media (max-width: 768px) {
+      transition: 0.2s;
+      width: 4px;
+    }
+  }
+`;
+const PharmContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 95px);
+`;
+const PharmHeadContainer = styled.div`
+  margin-right: 42px;
+  margin-bottom: 10px;
+  transition: 0.2s;
+  @media (max-width: 768px) {
+    transition: 0.2s;
+    margin-right: 22px;
+  }
+`;
+const PharmItemContainer = styled.div`
+  overflow-y: scroll;
+  height: calc(100vh - 135px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 10px;
+  box-shadow: rgba(0, 0, 0, 0.05) 2px 2px 4px inset, rgba(0, 0, 0, 0.05) 0px 7px 7px -3px inset,
+    rgba(0, 0, 0, 0.05) 0px -7px 7px -3px inset;
 `;
 
-//input 컨테이너
+//input
 const SearchContainer = styled.div`
-  width: 36.688rem;
   display: flex;
   justify-content: center;
-  padding: 2rem 1.5rem 1rem 1.5rem;
+  margin: 10px 0;
   .searchIcon {
     width: 1.5rem;
     height: 1.5rem;
     display: inline-block;
     position: absolute;
-    opacity: 0.5;
+    opacity: 0.4;
     margin: 0.8rem;
   }
 `;
-
-//input 창
 const SearchInput = styled.input`
-  width: 24rem;
+  width: 26rem;
   height: 3rem;
   border-radius: 10px;
-  border: 5px solid var(--blue-500);
+  border: 3px solid var(--blue-300);
   outline: none;
   font-size: 1.1rem;
   padding-left: 2.8rem;
+  transition: 0.2s;
+  :focus {
+    border-color: var(--blue-400);
+    box-shadow: var(--wrapped-shadow);
+    transition: 0.2s;
+  }
 `;
 
-//필터부분
-const PharmHeadContainer = styled.div`
+//Buttons
+const ButtonContainer = styled.div`
   display: flex;
-  justify-content: space-between;
-  margin-right: 3.1rem;
-  margin-top: 1.8rem;
-  margin-left: 6.25rem;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin: 25px 5px 3px 5px;
 `;
-//필터 버튼들
-const FilterButtons = styled.div`
-  vertical-align: baseline;
-  border: 1px solid var(--black-350);
-  border-radius: 5px;
-  border: none;
-`;
-//필터버튼
-const FilterButton = styled.button`
-  background-color: var(--white);
-  border: none;
-  color: var(--black-350);
-  font-size: 0.9rem;
-  width: 6.25rem;
-  &.filter_close {
-    border-top-left-radius: 8px 8px;
-    border-bottom-left-radius: 8px 8px;
-    border-right: 1px solid var(--black-350);
-  }
-  &.filter_popular {
-    border-right: 1px solid var(--black-350);
-  }
-  &.filter_star {
-    border-top-right-radius: 8px 8px;
-    border-bottom-right-radius: 8px 8px;
-  }
-  &:hover {
-    color: var(--blue-500);
-  }
-`;
-
-//약국카드
-const PharmCard = styled.div`
-  width: 35rem;
-  height: 25rem;
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  border-bottom: 1px solid var(--black-100);
-  .pharm_img {
-    background-color: var(--black-200);
-    object-fit: cover;
-    width: 23.75rem;
-    height: 15.625rem;
-    display: flex;
-    justify-content: center;
-    margin: auto;
-    border-radius: 10px;
-  }
-`;
-//하트 버튼!!
-const HeartPosition = styled.div`
-  position: relative;
-`;
-const HeartButton = styled.button`
-  all: unset;
-  cursor: pointer;
-
-  img {
-    position: absolute;
-    right: 6rem;
-    top: 3rem;
-  }
-`;
-
-//약국 타이틀
-const PharmTitleBox = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
-const PharmName = styled.div`
-  font-size: 1.56rem;
-  font-weight: bold;
-  margin-right: 4rem;
-`;
-
-//태그전체
-const TagContainer = styled.div`
-  margin-top: 0.5rem;
-  margin-left: 5rem;
-  margin-bottom: 0.5rem;
-`;
-
 //우리약국 가기
 const Button = styled.button`
   all: unset;
   cursor: pointer;
+  margin-right: 88px;
   .ourpharm_img {
     margin-right: 0.3rem;
   }
   .ourpharm {
     font-size: 1rem;
     color: var(--blue-500);
+    transition: 0.2s;
+    &:hover {
+      font-weight: 600;
+      color: var(--blue-600);
+      transition: 0.2s;
+    }
+  }
+`;
+const FilterButtons = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  .partition {
+    width: 1.4px;
+    height: 0.9rem;
+    background-color: var(--black-300);
+    margin: 0 15px;
+  }
+`;
+const FilterButton = styled.button`
+  cursor: pointer;
+  background-color: var(--white);
+  border: none;
+  color: var(--black-350);
+  font-size: 0.9rem;
+  transition: 0.2s;
+  &:hover {
+    color: var(--blue-500);
+    transition: 0.2s;
   }
 `;

--- a/front/src/Components/Ul/PharmRank.tsx
+++ b/front/src/Components/Ul/PharmRank.tsx
@@ -12,7 +12,8 @@ export default function PharmRank() {
     <Container>
       <div>{starPoint ? <BsStarFill className="select_star" /> : <BsStar className="unSelect_star" />}</div>
       <Star> {starPoint}/5 </Star>
-      <Selected>찜콩 45 /</Selected>
+      <Selected>찜콩 45</Selected>
+      <span className="partition" />
       <TotalReview> 리뷰 113</TotalReview>
     </Container>
   );
@@ -31,17 +32,23 @@ const Container = styled.div`
     font-size: 1.2rem;
     color: var(--mint);
   }
+  .partition {
+    width: 1.4px;
+    height: 1rem;
+    background-color: var(--black-300);
+    margin: 0 12px;
+  }
 `;
 
 const Star = styled.span`
   font-weight: bold;
   font-size: 1.3rem;
-  margin-right: 1.9rem;
+  margin-right: 1.2rem;
+  padding-bottom: 2px;
 `;
 
 const Selected = styled.span`
   color: var(--black-400);
-  margin-right: 0.7rem;
 `;
 const TotalReview = styled.span`
   color: var(--black-400);


### PR DESCRIPTION
# FE_style/pharmlist 약국리스트 레이아웃 및 CSS 수정
### 변경내용
1. 전체적으로 레이아웃 수정
2. 반응형 구현
3. CSS 애니메이션 추가
4. 약국 리스트에만 스크롤 적용되도록 수정
5. 모달창 위치 수정
6. 약국리스트와 약국아이템 분리


https://user-images.githubusercontent.com/107192580/224503841-731ae68d-9900-4625-a133-1bc6c6151425.mp4

