### PR TITLE
FE_feat/adminReports 관리자 계정 <신고리뷰관리/> 화면구현

### DIFF
--- a/front/src/Components/Ul/Button.tsx
+++ b/front/src/Components/Ul/Button.tsx
@@ -9,7 +9,7 @@ interface BtnProps {
   url?: string;
   icon?: boolean;
   disabled?: boolean;
-  onClick?: ()=>void;
+  onClick?: () => void;
 }
 
 export default function Button({ text, icon, color, size, url, disabled, onClick }: BtnProps) {

--- a/front/src/Components/Ul/Button.tsx
+++ b/front/src/Components/Ul/Button.tsx
@@ -9,7 +9,8 @@ interface BtnProps {
   url?: string;
   icon?: boolean;
   disabled?: boolean;
-  onClick?: () => void;
+  // onClick?: () => void;
+  onClick?: any;
 }
 
 export default function Button({ text, icon, color, size, url, disabled, onClick }: BtnProps) {

--- a/front/src/Components/Ul/Button.tsx
+++ b/front/src/Components/Ul/Button.tsx
@@ -9,7 +9,7 @@ interface BtnProps {
   url?: string;
   icon?: boolean;
   disabled?: boolean;
-  onClick?: any;
+  onClick?: ()=>void;
 }
 
 export default function Button({ text, icon, color, size, url, disabled, onClick }: BtnProps) {

--- a/front/src/Components/Ul/Button.tsx
+++ b/front/src/Components/Ul/Button.tsx
@@ -9,7 +9,6 @@ interface BtnProps {
   url?: string;
   icon?: boolean;
   disabled?: boolean;
-  // onClick?: () => void;
   onClick?: any;
 }
 

--- a/front/src/Pages/Admin/AdminTabs.tsx
+++ b/front/src/Pages/Admin/AdminTabs.tsx
@@ -8,9 +8,15 @@ interface ThisTab {
 export default function AdminTabs({ current }: ThisTab) {
   return (
     <TabContainer>
-      <Tabs to="/admin-reports" className={current==="reports"?"this":""}>신고리뷰 관리</Tabs>
-      <Tabs to="/admin-users" className={current==="users"?"this":""}>전체회원 관리</Tabs>
-      <Tabs to="/admin-certify" className={current==="certify"?"this":""}>약사인증 관리</Tabs>
+      <Tabs to="/admin-reports" className={current === "reports" ? "this" : ""}>
+        신고리뷰 관리
+      </Tabs>
+      <Tabs to="/admin-users" className={current === "users" ? "this" : ""}>
+        전체회원 관리
+      </Tabs>
+      <Tabs to="/admin-certify" className={current === "certify" ? "this" : ""}>
+        약사인증 관리
+      </Tabs>
     </TabContainer>
   );
 }
@@ -18,15 +24,18 @@ export default function AdminTabs({ current }: ThisTab) {
 const TabContainer = styled.div`
   display: flex;
   justify-content: flex-start;
-  flex-grow: 1;
-  height: 3rem;
+  align-items: flex-end;
+  /* flex-grow: 1; */
+  height: 70px;
+  padding-top: 10px;
 `;
 const Tabs = styled(Link)`
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  margin-top: 0.5rem;
-  padding: 0 3rem 0 1.5rem;
+  padding-left: 20px;
+  width: 150px;
+  height: 50px;
   text-decoration: none;
   font-size: 18px;
   font-weight: bold;

--- a/front/src/Pages/Admin/AdminTabs.tsx
+++ b/front/src/Pages/Admin/AdminTabs.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+interface ThisTab {
+  current?: string;
+}
+
+export default function AdminTabs({ current }: ThisTab) {
+  return (
+    <TabContainer>
+      <Tabs to="/admin-reports" className={current==="reports"?"this":""}>신고리뷰 관리</Tabs>
+      <Tabs to="/admin-users" className={current==="users"?"this":""}>전체회원 관리</Tabs>
+      <Tabs to="/admin-certify" className={current==="certify"?"this":""}>약사인증 관리</Tabs>
+    </TabContainer>
+  );
+}
+
+const TabContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex-grow: 1;
+  height: 3rem;
+`;
+const Tabs = styled(Link)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 0.5rem;
+  padding: 0 3rem 0 1.5rem;
+  text-decoration: none;
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--black-500);
+  border: 1px solid var(--black-100);
+  border-bottom: none;
+  border-radius: 10px 10px 0px 0px;
+  background-color: var(--black-050);
+  :hover {
+    background-color: var(--black-075);
+  }
+  &.this {
+    color: var(--black);
+    background-color: var(--white);
+  }
+`;

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -1,17 +1,72 @@
-import { useState } from "react";
 import styled from "styled-components";
+import AdminTabs from "./AdminTabs"
 import Button from "../../Components/Ul/Button";
 import CheckBox from "../../Components/Ul/CheckBox";
+import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 export default function Reports() {
+  const dummy = [
+    {
+      content: "약사 대머리임 ㅋㅋㅋㅋㅋ",
+      email: "waiting@kbs.com",
+      writtenAt: "2023.02.01",
+      reports: 12,
+    },
+    {
+      content: "잘되면 재밌고 잘안되면 재미없고",
+      email: "boring@coding.com",
+      writtenAt: "2023.02.01",
+      reports: 13,
+    },
+    {
+      content:
+        "얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버얼마안남았다존버",
+      email: "codestates@bootcamp.com",
+      writtenAt: "2023.02.01",
+      reports: 2,
+    },
+    {
+      content: "자바칩프라푸치노 자몽허니블랙티 아이스시그니처초콜릿",
+      email: "starbucks@gyeongju.com",
+      writtenAt: "2023.02.01",
+      reports: 6,
+    },
+    {
+      content: "토피넛라떼 바닐라크림콜드브루 아이스카푸치노",
+      email: "starbucks@gyeongju.com",
+      writtenAt: "2023.02.01",
+      reports: 8,
+    },
+    {
+      content: "sfgsfdgshdfgjhkhjkdghjdghsgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgsdfgdfgsdfgsdf",
+      email: "waiting@kbs.com",
+      writtenAt: "2023.02.01",
+      reports: 36,
+    },
+    {
+      content: "오늘은 미세먼지가 아주 많습니다.",
+      email: "yeonjinPArk@giKae.com",
+      writtenAt: "2023.02.01",
+      reports: 2,
+    },
+    {
+      content: "할렐루야",
+      email: "powerDrugger@weeeeeed.com",
+      writtenAt: "2023.02.01",
+      reports: 3,
+    },
+    {
+      content: "전예솔!!!!!!!!!!!!!!!!!!!!!!!!!!",
+      email: "colorBlind@yesolDad.com",
+      writtenAt: "2023.02.01",
+      reports: 1,
+    },
+  ];
+
   return (
     <WholePage>
       <Wrapper>
-        <TabContainer>
-          <Tabs>신고리뷰 관리</Tabs>
-          <Tabs>전체회원 관리</Tabs>
-          <Tabs>약사인증 관리</Tabs>
-        </TabContainer>
+        <AdminTabs current="reports"/>
         <Page>
           <Header>
             <span>신고리뷰관리</span>
@@ -21,20 +76,31 @@ export default function Reports() {
             </ButtonContainer>
           </Header>
           <Table>
-            <Labels>
+            <Label>
               <CheckBox />
-              <Values className="content title">내용</Values>
-              <Values className="email title">email</Values>
-              <Values className="writtenAt title">작성일</Values>
-              <Values className="reports title">신고 수</Values>
-            </Labels>
-            <Content>
-              <CheckBox />
-              <Values className="content">약사 대머리임 ㅋㅋㅋㅋㅋ</Values>
-              <Values className="email">waiting@kbs.com</Values>
-              <Values className="writtenAt">2023.01.07</Values>
-              <Values className="reports">12</Values>
-            </Content>
+              <Values className="content">내용</Values>
+              <Values className="email">email</Values>
+              <Values className="writtenAt">작성일</Values>
+              <Values className="reports">신고 수</Values>
+            </Label>
+            {dummy.length ? (
+              <BelowLable>
+                {dummy.map((data) => (
+                  <Content>
+                    <CheckBox />
+                    <Values className="content">{data.content}</Values>
+                    <Values className="email">{data.email}</Values>
+                    <Values className="writtenAt">{data.writtenAt}</Values>
+                    <Values className="reports">{data.reports}</Values>
+                  </Content>
+                ))}
+              </BelowLable>
+            ) : (
+              <Instead>
+                <AiOutlineExclamationCircle />
+                <span>신고된 리뷰가 없습니다.</span>
+              </Instead>
+            )}
           </Table>
         </Page>
       </Wrapper>
@@ -43,50 +109,35 @@ export default function Reports() {
 }
 
 const WholePage = styled.div`
-  background-color: gray;
-  /*  */
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100vw;
   height: calc(100vh - 52px);
-`
-const Wrapper = styled.div`
-  border: 1px solid green;
-  background-color: var(--white);
+`;
+const Wrapper = styled.main`
   /*  */
   display: flex;
   flex-direction: column;
   justify-content: center;
-  width: 1000px;
-  height: 600px;
-`;
-const TabContainer = styled.div`
-  border: 1px solid green;
-  background-color: gray;
-  /*  */
-  display: flex;
-  justify-content: flex-start;
-  height: 50px;
-`;
-const Tabs = styled.button`
-  border: 1px solid green;
-  /*  */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 5px 20px;
-  font-size: 18px;
+  width: 80rem;
+  height: 40rem;
+  overflow: hidden;
+  border-radius: 15px;
+  border: 2px solid var(--black-200);
+  box-shadow: var(--wrapped-shadow);
+  background-color: var(--black-075);
 `;
 const Page = styled.article`
-  border: 1px solid green;
-  /*  */
-  height: calc(600px - 50px);
-  padding: 30px 20px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  padding: 15px 50px;
+  border-top: 1.5px solid var(--black-100);
+  border-radius: 0 10px 0 0;
+  background-color: var(--white);
 `;
 const Header = styled.header`
-  border: 1px solid green;
-  /*  */
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -97,37 +148,74 @@ const Header = styled.header`
   }
 `;
 const ButtonContainer = styled.div`
-  border: 1px solid green;
-  /*  */
   display: flex;
   gap: 20px;
 `;
 const Table = styled.figure`
-  border: 1px solid green;
-  /*  */
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 `;
-const Labels = styled.div`
-  border: 1px solid green;
-  /*  */
+const Label = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
+  padding: 10px calc(20px + 0.6rem) 10px 20px;
+  font-size: 1.2rem;
+  font-weight: bolder;
+  color: var(--black-500);
+  border-top: 1.5px solid var(--black-100);
+  border-bottom: 1.5px solid var(--black-100);
+  background-color: var(--black-050);
+`;
+const BelowLable = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 26rem;
+  overflow-y: scroll;
+  background-color: var(--black-050);
+`;
+const Instead = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  padding: 7px 20px 7px 20px;
+  gap: 20px;
+  height: 26rem;
+  color: var(--black-100);
+  font-size: 6rem;
+  font-weight: bold;
+  background-color: var(--black-025);
+  span {
+    font-size: 2rem;
+  }
 `;
 const Content = styled.div`
-  border: 1px solid green;
-  /*  */
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7px 20px 7px 20px;
-  &.title {}
-  &.content {}
-  &.email {}
-  &.writtenAt {}
-  &.reports {}
+  padding: 10px 20px;
+  border-bottom: 0.5px solid var(--black-075);
+  background-color: var(--white);
+  :hover {
+    background-color: var(--black-050);
+  }
 `;
 const Values = styled.span`
-  border: 1px solid green;
-  /*  */
+  display: flex;
+  justify-content: center;
+  &.content {
+    width: 30rem;
+    white-space: normal;
+    word-break: break-all;
+  }
+  &.email {
+    width: 20rem;
+  }
+  &.writtenAt {
+    width: 10rem;
+  }
+  &.reports {
+    width: 5rem;
+  }
 `;

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import AdminTabs from "./AdminTabs"
+import AdminTabs from "./AdminTabs";
 import Button from "../../Components/Ul/Button";
 import CheckBox from "../../Components/Ul/CheckBox";
 import { AiOutlineExclamationCircle } from "react-icons/ai";
@@ -66,7 +66,7 @@ export default function Reports() {
   return (
     <WholePage>
       <Wrapper>
-        <AdminTabs current="reports"/>
+        <AdminTabs current="reports" />
         <Page>
           <Header>
             <span>신고리뷰관리</span>
@@ -77,7 +77,9 @@ export default function Reports() {
           </Header>
           <Table>
             <Label>
-              <CheckBox />
+              <Values className="checkBox">
+                <CheckBox />
+              </Values>
               <Values className="content">내용</Values>
               <Values className="email">email</Values>
               <Values className="writtenAt">작성일</Values>
@@ -87,7 +89,9 @@ export default function Reports() {
               <BelowLable>
                 {dummy.map((data) => (
                   <Content>
-                    <CheckBox />
+                    <Values className="checkBox">
+                      <CheckBox />
+                    </Values>
                     <Values className="content">{data.content}</Values>
                     <Values className="email">{data.email}</Values>
                     <Values className="writtenAt">{data.writtenAt}</Values>
@@ -116,10 +120,10 @@ const WholePage = styled.div`
   height: calc(100vh - 52px);
 `;
 const Wrapper = styled.main`
-  /*  */
   display: flex;
   flex-direction: column;
   justify-content: center;
+  margin: 0 20px;
   width: 80rem;
   height: 40rem;
   overflow: hidden;
@@ -131,8 +135,8 @@ const Wrapper = styled.main`
 const Page = styled.article`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  padding: 15px 50px;
+  height: 40rem;
+  padding: 15px 55px;
   border-top: 1.5px solid var(--black-100);
   border-radius: 0 10px 0 0;
   background-color: var(--white);
@@ -141,10 +145,13 @@ const Header = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
+  padding: 20px 5px 20px 20px;
   span {
     font-size: 20px;
     font-weight: bold;
+  }
+  @media (max-width: 768px) {
+    padding: 20px 0px 20px 20px;
   }
 `;
 const ButtonContainer = styled.div`
@@ -154,12 +161,23 @@ const ButtonContainer = styled.div`
 const Table = styled.figure`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  height: 450px;
+  overflow-x: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  @media (max-width: 768px) {
+    overflow-x: scroll;
+    ::-webkit-scrollbar {
+      display: block;
+    }
+  }
 `;
 const Label = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  width: calc(1150px + 0.6rem);
   padding: 10px calc(20px + 0.6rem) 10px 20px;
   font-size: 1.2rem;
   font-weight: bolder;
@@ -172,6 +190,7 @@ const BelowLable = styled.div`
   display: flex;
   flex-direction: column;
   height: 26rem;
+  width: calc(1150px + 0.6rem);
   overflow-y: scroll;
   background-color: var(--black-050);
 `;
@@ -204,18 +223,21 @@ const Content = styled.div`
 const Values = styled.span`
   display: flex;
   justify-content: center;
+  &.checkBox {
+    padding-left: 7px;
+  }
   &.content {
-    width: 30rem;
+    width: 400px;
     white-space: normal;
     word-break: break-all;
   }
   &.email {
-    width: 20rem;
+    width: 300px;
   }
   &.writtenAt {
-    width: 10rem;
+    width: 150px;
   }
   &.reports {
-    width: 5rem;
+    width: 60px;
   }
 `;

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -1,10 +1,133 @@
-import React from 'react';
+import { useState } from "react";
+import styled from "styled-components";
+import Button from "../../Components/Ul/Button";
+import CheckBox from "../../Components/Ul/CheckBox";
 
 export default function Reports() {
   return (
-    <div>
-      
-    </div>
+    <WholePage>
+      <Wrapper>
+        <TabContainer>
+          <Tabs>신고리뷰 관리</Tabs>
+          <Tabs>전체회원 관리</Tabs>
+          <Tabs>약사인증 관리</Tabs>
+        </TabContainer>
+        <Page>
+          <Header>
+            <span>신고리뷰관리</span>
+            <ButtonContainer>
+              <Button color="blue" size="md" text="선택삭제" />
+              <Button color="blue" size="md" text="선택복구" />
+            </ButtonContainer>
+          </Header>
+          <Table>
+            <Labels>
+              <CheckBox />
+              <Values className="content title">내용</Values>
+              <Values className="email title">email</Values>
+              <Values className="writtenAt title">작성일</Values>
+              <Values className="reports title">신고 수</Values>
+            </Labels>
+            <Content>
+              <CheckBox />
+              <Values className="content">약사 대머리임 ㅋㅋㅋㅋㅋ</Values>
+              <Values className="email">waiting@kbs.com</Values>
+              <Values className="writtenAt">2023.01.07</Values>
+              <Values className="reports">12</Values>
+            </Content>
+          </Table>
+        </Page>
+      </Wrapper>
+    </WholePage>
   );
 }
 
+const WholePage = styled.div`
+  background-color: gray;
+  /*  */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: calc(100vh - 52px);
+`
+const Wrapper = styled.div`
+  border: 1px solid green;
+  background-color: var(--white);
+  /*  */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 1000px;
+  height: 600px;
+`;
+const TabContainer = styled.div`
+  border: 1px solid green;
+  background-color: gray;
+  /*  */
+  display: flex;
+  justify-content: flex-start;
+  height: 50px;
+`;
+const Tabs = styled.button`
+  border: 1px solid green;
+  /*  */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 20px;
+  font-size: 18px;
+`;
+const Page = styled.article`
+  border: 1px solid green;
+  /*  */
+  height: calc(600px - 50px);
+  padding: 30px 20px;
+`;
+const Header = styled.header`
+  border: 1px solid green;
+  /*  */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  span {
+    font-size: 20px;
+    font-weight: bold;
+  }
+`;
+const ButtonContainer = styled.div`
+  border: 1px solid green;
+  /*  */
+  display: flex;
+  gap: 20px;
+`;
+const Table = styled.figure`
+  border: 1px solid green;
+  /*  */
+`;
+const Labels = styled.div`
+  border: 1px solid green;
+  /*  */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7px 20px 7px 20px;
+`;
+const Content = styled.div`
+  border: 1px solid green;
+  /*  */
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7px 20px 7px 20px;
+  &.title {}
+  &.content {}
+  &.email {}
+  &.writtenAt {}
+  &.reports {}
+`;
+const Values = styled.span`
+  border: 1px solid green;
+  /*  */
+`;


### PR DESCRIPTION
## 1. 컴포넌트 구조
<img width="700px" alt="image" src="https://user-images.githubusercontent.com/115776596/224537808-b353a52f-6447-49a8-bb2c-071bfb2a11aa.png">

## 2. 신고리뷰 갯수별 화면 상태
### 신고리뷰가 하나도 없을 때
<img width="700px" alt="image" src="https://user-images.githubusercontent.com/115776596/224537879-69da8ded-9ac9-44de-8eff-4d411d1e5504.png">

### 신고리뷰가 세로범위를 넘지 않을 때 `scroll disabled`
<img width="700px" alt="image" src="https://user-images.githubusercontent.com/115776596/224537945-b7f9c5f0-6e91-47e7-8e79-4c43abe6e955.png"> 

### 신고리뷰가 세로범위를 초과할 때 `scroll`
<img width="700px" alt="image" src="https://user-images.githubusercontent.com/115776596/224538001-1637490d-2a7c-4311-a828-411fde8962bd.png">

## 3. 반응형 구현
### 화면너비가 764px까지 줄어들 경우, 가로 스크롤이 생성됩니다.
https://user-images.githubusercontent.com/115776596/224538091-f46a97df-5415-4916-ae6b-bb768aa962c1.mov

