### PR TITLE
FE_feat/adminUsers 관리자계정 전체회원관리 화면구현

### DIFF
--- a/front/src/Pages/Admin/AdminTabs.tsx
+++ b/front/src/Pages/Admin/AdminTabs.tsx
@@ -21,7 +21,7 @@ export default function AdminTabs({ current }: ThisTab) {
   );
 }
 
-const TabContainer = styled.div`
+const TabContainer = styled.header`
   display: flex;
   justify-content: flex-start;
   align-items: flex-end;

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -87,8 +87,8 @@ export default function Reports() {
             </Label>
             {dummy.length ? (
               <BelowLable>
-                {dummy.map((data) => (
-                  <Content>
+                {dummy.map((data, i) => (
+                  <Content key={i}>
                     <Values className="checkBox">
                       <CheckBox />
                     </Values>

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -112,7 +112,7 @@ export default function Reports() {
   );
 }
 
-const WholePage = styled.div`
+const WholePage = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -132,7 +132,7 @@ const Wrapper = styled.main`
   box-shadow: var(--wrapped-shadow);
   background-color: var(--black-075);
 `;
-const Page = styled.article`
+const Page = styled.section`
   display: flex;
   flex-direction: column;
   height: 40rem;
@@ -154,7 +154,7 @@ const Header = styled.header`
     padding: 20px 0px 20px 20px;
   }
 `;
-const ButtonContainer = styled.div`
+const ButtonContainer = styled.section`
   display: flex;
   gap: 20px;
 `;
@@ -173,7 +173,7 @@ const Table = styled.figure`
     }
   }
 `;
-const Label = styled.div`
+const Label = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -186,7 +186,7 @@ const Label = styled.div`
   border-bottom: 1.5px solid var(--black-100);
   background-color: var(--black-050);
 `;
-const BelowLable = styled.div`
+const BelowLable = styled.section`
   display: flex;
   flex-direction: column;
   height: 26rem;
@@ -194,7 +194,7 @@ const BelowLable = styled.div`
   overflow-y: scroll;
   background-color: var(--black-050);
 `;
-const Instead = styled.div`
+const Instead = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -209,7 +209,7 @@ const Instead = styled.div`
     font-size: 2rem;
   }
 `;
-const Content = styled.div`
+const Content = styled.article`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -62,7 +62,7 @@ export default function Users() {
             <span>전체회원관리</span>
             <ButtonContainer>
               <Select>
-                <option>정지옵션</option>
+                <Option>정지옵션</Option>
                 <option>3개월</option>
                 <option>6개월</option>
                 <option>9개월</option>
@@ -114,7 +114,7 @@ export default function Users() {
   );
 }
 
-const WholePage = styled.div`
+const WholePage = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -134,7 +134,7 @@ const Wrapper = styled.main`
   box-shadow: var(--wrapped-shadow);
   background-color: var(--black-075);
 `;
-const Page = styled.article`
+const Page = styled.section`
   display: flex;
   flex-direction: column;
   height: 40rem;
@@ -156,24 +156,20 @@ const Header = styled.header`
     padding: 20px 0px 20px 20px;
   }
 `;
-const ButtonContainer = styled.div`
+const ButtonContainer = styled.section`
   display: flex;
   gap: 20px;
 `;
 const Select = styled.select`
-  border: 1.2px solid var(--l_button-blue);
-  color: var(--l_button-blue);
   cursor: pointer;
   padding: 0.5rem;
+  color: var(--l_button-blue);
   border-radius: 3px;
+  border: 1.2px solid var(--l_button-blue);
+  :focus { outline: none}
 `;
 const Option = styled.option`
-  line-height: 1.1;
-  padding: 0.5rem 1rem;
-  /* 버튼 위 라인 효과 */
-  box-shadow: inset 0 1px 0 0 hsl(0, 0%, 100%, 0.4);
-  border: 1px solid transparent;
-  text-decoration: none;
+
 `;
 const Table = styled.figure`
   display: flex;
@@ -190,7 +186,7 @@ const Table = styled.figure`
     }
   }
 `;
-const Label = styled.div`
+const Label = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -203,7 +199,7 @@ const Label = styled.div`
   border-bottom: 1.5px solid var(--black-100);
   background-color: var(--black-050);
 `;
-const BelowLable = styled.div`
+const BelowLable = styled.section`
   display: flex;
   flex-direction: column;
   height: 26rem;
@@ -211,7 +207,7 @@ const BelowLable = styled.div`
   overflow-y: scroll;
   background-color: var(--black-050);
 `;
-const Instead = styled.div`
+const Instead = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -226,7 +222,7 @@ const Instead = styled.div`
     font-size: 2rem;
   }
 `;
-const Content = styled.div`
+const Content = styled.article`
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -1,10 +1,205 @@
-import React from 'react';
+import styled from "styled-components";
+import AdminTabs from "./AdminTabs"
+import Button from "../../Components/Ul/Button";
+import CheckBox from "../../Components/Ul/CheckBox";
+import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 export default function Users() {
+  const dummy = [
+    {
+      content: "약사 대머리임 ㅋㅋㅋㅋㅋ",
+      email: "waiting@kbs.com",
+      writtenAt: "2023.02.01",
+      reports: 12,
+    },
+    {
+      content: "잘되면 재밌고 잘안되면 재미없고",
+      email: "boring@coding.com",
+      writtenAt: "2023.02.01",
+      reports: 13,
+    },
+  ];
+
   return (
-    <div>
-      
-    </div>
+    <WholePage>
+      <Wrapper>
+        <AdminTabs current="users" />
+        <Page>
+          <Header>
+            <span>전체회원관리</span>
+            <ButtonContainer>
+              <select>
+                <option>3개월</option>
+                <option>6개월</option>
+                <option>9개월</option>
+              </select>
+              <Button color="blue" size="md" text="선택정지" />
+              <Button color="blue" size="md" text="선택강퇴" />
+            </ButtonContainer>
+          </Header>
+          <Table>
+            <Label>
+              <Values className="checkBox">
+                <CheckBox />
+              </Values>
+              <Values className="content">내용</Values>
+              <Values className="email">email</Values>
+              <Values className="writtenAt">작성일</Values>
+              <Values className="reports">신고 수</Values>
+            </Label>
+            {dummy.length ? (
+              <BelowLable>
+                {dummy.map((data) => (
+                  <Content>
+                    <Values className="checkBox">
+                      <CheckBox />
+                    </Values>
+                    <Values className="content">{data.content}</Values>
+                    <Values className="email">{data.email}</Values>
+                    <Values className="writtenAt">{data.writtenAt}</Values>
+                    <Values className="reports">{data.reports}</Values>
+                  </Content>
+                ))}
+              </BelowLable>
+            ) : (
+              <Instead>
+                <AiOutlineExclamationCircle />
+                <span>가입된 회원이 없습니다.</span>
+              </Instead>
+            )}
+          </Table>
+        </Page>
+      </Wrapper>
+    </WholePage>
   );
 }
 
+const WholePage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: calc(100vh - 52px);
+`;
+const Wrapper = styled.main`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 20px;
+  width: 80rem;
+  height: 40rem;
+  overflow: hidden;
+  border-radius: 15px;
+  border: 2px solid var(--black-200);
+  box-shadow: var(--wrapped-shadow);
+  background-color: var(--black-075);
+`;
+const Page = styled.article`
+  display: flex;
+  flex-direction: column;
+  height: 40rem;
+  padding: 15px 55px;
+  border-top: 1.5px solid var(--black-100);
+  border-radius: 0 10px 0 0;
+  background-color: var(--white);
+`;
+const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 5px 20px 20px;
+  span {
+    font-size: 20px;
+    font-weight: bold;
+  }
+  @media (max-width: 768px) {
+    padding: 20px 0px 20px 20px;
+  }
+`;
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: 20px;
+`;
+const Table = styled.figure`
+  display: flex;
+  flex-direction: column;
+  height: 450px;
+  overflow-x: scroll;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  @media (max-width: 768px) {
+    overflow-x: scroll;
+    ::-webkit-scrollbar {
+      display: block;
+    }
+  }
+`;
+const Label = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: calc(1150px + 0.6rem);
+  padding: 10px calc(20px + 0.6rem) 10px 20px;
+  font-size: 1.2rem;
+  font-weight: bolder;
+  color: var(--black-500);
+  border-top: 1.5px solid var(--black-100);
+  border-bottom: 1.5px solid var(--black-100);
+  background-color: var(--black-050);
+`;
+const BelowLable = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 26rem;
+  width: calc(1150px + 0.6rem);
+  overflow-y: scroll;
+  background-color: var(--black-050);
+`;
+const Instead = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  height: 26rem;
+  color: var(--black-100);
+  font-size: 6rem;
+  font-weight: bold;
+  background-color: var(--black-025);
+  span {
+    font-size: 2rem;
+  }
+`;
+const Content = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+  border-bottom: 0.5px solid var(--black-075);
+  background-color: var(--white);
+  :hover {
+    background-color: var(--black-050);
+  }
+`;
+const Values = styled.span`
+  display: flex;
+  justify-content: center;
+  &.checkBox {
+    padding-left: 7px;
+  }
+  &.content {
+    width: 400px;
+    white-space: normal;
+    word-break: break-all;
+  }
+  &.email {
+    width: 300px;
+  }
+  &.writtenAt {
+    width: 150px;
+  }
+  &.reports {
+    width: 60px;
+  }
+`;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -168,9 +168,7 @@ const Select = styled.select`
   border: 1.2px solid var(--l_button-blue);
   :focus { outline: none}
 `;
-const Option = styled.option`
-
-`;
+const Option = styled.option``;
 const Table = styled.figure`
   display: flex;
   flex-direction: column;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import AdminTabs from "./AdminTabs"
+import AdminTabs from "./AdminTabs";
 import Button from "../../Components/Ul/Button";
 import CheckBox from "../../Components/Ul/CheckBox";
 import { AiOutlineExclamationCircle } from "react-icons/ai";
@@ -7,16 +7,49 @@ import { AiOutlineExclamationCircle } from "react-icons/ai";
 export default function Users() {
   const dummy = [
     {
-      content: "약사 대머리임 ㅋㅋㅋㅋㅋ",
-      email: "waiting@kbs.com",
-      writtenAt: "2023.02.01",
-      reports: 12,
+      classification: "약사",
+      accountStatus: "active",
+      nickname: "johnsFavourite",
+      email: "papa@johns.com",
+      subscription: "2023.02.13",
+      reviewCount: 4,
+      reportCount: 0,
     },
     {
-      content: "잘되면 재밌고 잘안되면 재미없고",
-      email: "boring@coding.com",
-      writtenAt: "2023.02.01",
-      reports: 13,
+      classification: "일반",
+      accountStatus: "suspended",
+      nickname: "MarchApril",
+      email: "papa@johns.com",
+      subscription: "1996.04.25",
+      reviewCount: 6,
+      reportCount: 99,
+    },
+    {
+      classification: "약사",
+      accountStatus: "active",
+      nickname: "February",
+      email: "painting@landscape.com",
+      subscription: "2019.02.13",
+      reviewCount: 3,
+      reportCount: 0,
+    },
+    {
+      classification: "일반",
+      accountStatus: "active",
+      nickname: "JuneJuly",
+      email: "surfing@hawaii.com",
+      subscription: "2021.07.24",
+      reviewCount: 20,
+      reportCount: 0,
+    },
+    {
+      classification: "일반",
+      accountStatus: "suspended",
+      nickname: "McMorning",
+      email: "Mcdonalds@maccas.com",
+      subscription: "2023.03.13",
+      reviewCount: 45,
+      reportCount: 20,
     },
   ];
 
@@ -28,11 +61,12 @@ export default function Users() {
           <Header>
             <span>전체회원관리</span>
             <ButtonContainer>
-              <select>
-                <option>3개월</option>
-                <option>6개월</option>
-                <option>9개월</option>
-              </select>
+              <Select>
+                <Option>정지옵션</Option>
+                <Option>3개월</Option>
+                <Option>6개월</Option>
+                <Option>9개월</Option>
+              </Select>
               <Button color="blue" size="md" text="선택정지" />
               <Button color="blue" size="md" text="선택강퇴" />
             </ButtonContainer>
@@ -42,22 +76,28 @@ export default function Users() {
               <Values className="checkBox">
                 <CheckBox />
               </Values>
-              <Values className="content">내용</Values>
+              <Values className="classification">구분</Values>
+              <Values className="accountStatus">계정상태</Values>
+              <Values className="nickname">닉네임</Values>
               <Values className="email">email</Values>
-              <Values className="writtenAt">작성일</Values>
-              <Values className="reports">신고 수</Values>
+              <Values className="subscription">가입일</Values>
+              <Values className="reviewCount">리뷰 수</Values>
+              <Values className="reportCount">신고 수</Values>
             </Label>
             {dummy.length ? (
               <BelowLable>
-                {dummy.map((data) => (
-                  <Content>
+                {dummy.map((data, i) => (
+                  <Content key={i} className={data.accountStatus === "suspended" ? "suspended" : ""}>
                     <Values className="checkBox">
                       <CheckBox />
                     </Values>
-                    <Values className="content">{data.content}</Values>
+                    <Values className="classification">{data.classification}</Values>
+                    <Values className="accountStatus">{data.accountStatus}</Values>
+                    <Values className="nickname">{data.nickname}</Values>
                     <Values className="email">{data.email}</Values>
-                    <Values className="writtenAt">{data.writtenAt}</Values>
-                    <Values className="reports">{data.reports}</Values>
+                    <Values className="subscription">{data.subscription}</Values>
+                    <Values className="reviewCount">{data.reviewCount}</Values>
+                    <Values className="reportCount">{data.reportCount}</Values>
                   </Content>
                 ))}
               </BelowLable>
@@ -120,6 +160,24 @@ const ButtonContainer = styled.div`
   display: flex;
   gap: 20px;
 `;
+const Select = styled.select`
+  background-color: 1px solid green;
+
+  line-height: 1.1;
+  /* padding: 0.5rem 1rem; */
+  /* 버튼 위 라인 효과 */
+  box-shadow: inset 0 1px 0 0 hsl(0, 0%, 100%, 0.4);
+  border: 1px solid transparent;
+  text-decoration: none;
+`;
+const Option = styled.option`
+  line-height: 1.1;
+  padding: 0.5rem 1rem;
+  /* 버튼 위 라인 효과 */
+  box-shadow: inset 0 1px 0 0 hsl(0, 0%, 100%, 0.4);
+  border: 1px solid transparent;
+  text-decoration: none;
+`;
 const Table = styled.figure`
   display: flex;
   flex-direction: column;
@@ -178,6 +236,9 @@ const Content = styled.div`
   padding: 10px 20px;
   border-bottom: 0.5px solid var(--black-075);
   background-color: var(--white);
+  &.suspended {
+    color: var(--black-200);
+  }
   :hover {
     background-color: var(--black-050);
   }
@@ -188,18 +249,25 @@ const Values = styled.span`
   &.checkBox {
     padding-left: 7px;
   }
-  &.content {
-    width: 400px;
-    white-space: normal;
-    word-break: break-all;
+  &.classification {
+    width: 60px;
+  }
+  &.accountStatus {
+    width: 100px;
+  }
+  &.nickname {
+    width: 180px;
   }
   &.email {
-    width: 300px;
+    width: 240px;
   }
-  &.writtenAt {
-    width: 150px;
+  &.subscription {
+    width: 120px;
   }
-  &.reports {
+  &.reviewCount {
+    width: 60px;
+  }
+  &.reportCount {
     width: 60px;
   }
 `;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -62,10 +62,10 @@ export default function Users() {
             <span>전체회원관리</span>
             <ButtonContainer>
               <Select>
-                <Option>정지옵션</Option>
-                <Option>3개월</Option>
-                <Option>6개월</Option>
-                <Option>9개월</Option>
+                <option>정지옵션</option>
+                <option>3개월</option>
+                <option>6개월</option>
+                <option>9개월</option>
               </Select>
               <Button color="blue" size="md" text="선택정지" />
               <Button color="blue" size="md" text="선택강퇴" />
@@ -161,14 +161,11 @@ const ButtonContainer = styled.div`
   gap: 20px;
 `;
 const Select = styled.select`
-  background-color: 1px solid green;
-
-  line-height: 1.1;
-  /* padding: 0.5rem 1rem; */
-  /* 버튼 위 라인 효과 */
-  box-shadow: inset 0 1px 0 0 hsl(0, 0%, 100%, 0.4);
-  border: 1px solid transparent;
-  text-decoration: none;
+  border: 1.2px solid var(--l_button-blue);
+  color: var(--l_button-blue);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 3px;
 `;
 const Option = styled.option`
   line-height: 1.1;

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -11,6 +11,7 @@ export default function Users() {
       accountStatus: "active",
       nickname: "johnsFavourite",
       email: "papa@johns.com",
+      returnAt: "2023.02.25",
       subscription: "2023.02.13",
       reviewCount: 4,
       reportCount: 0,
@@ -20,6 +21,7 @@ export default function Users() {
       accountStatus: "suspended",
       nickname: "MarchApril",
       email: "papa@johns.com",
+      returnAt: "1996.04.13",
       subscription: "1996.04.25",
       reviewCount: 6,
       reportCount: 99,
@@ -29,7 +31,8 @@ export default function Users() {
       accountStatus: "active",
       nickname: "February",
       email: "painting@landscape.com",
-      subscription: "2019.02.13",
+      returnAt: "2019.02.13",
+      subscription: "2019.02.24",
       reviewCount: 3,
       reportCount: 0,
     },
@@ -38,6 +41,7 @@ export default function Users() {
       accountStatus: "active",
       nickname: "JuneJuly",
       email: "surfing@hawaii.com",
+      returnAt: "2021.07.13",
       subscription: "2021.07.24",
       reviewCount: 20,
       reportCount: 0,
@@ -47,7 +51,8 @@ export default function Users() {
       accountStatus: "suspended",
       nickname: "McMorning",
       email: "Mcdonalds@maccas.com",
-      subscription: "2023.03.13",
+      returnAt: "2023.03.25",
+      subscription: "2023.03.07",
       reviewCount: 45,
       reportCount: 20,
     },
@@ -63,12 +68,13 @@ export default function Users() {
             <ButtonContainer>
               <Select>
                 <Option>정지옵션</Option>
-                <option>3개월</option>
-                <option>6개월</option>
-                <option>9개월</option>
+                <option>3일</option>
+                <option>7일</option>
+                <option>30일</option>
               </Select>
               <Button color="blue" size="md" text="선택정지" />
               <Button color="blue" size="md" text="선택강퇴" />
+              <Button color="blue" size="md" text="선택복구" />
             </ButtonContainer>
           </Header>
           <Table>
@@ -80,6 +86,7 @@ export default function Users() {
               <Values className="accountStatus">계정상태</Values>
               <Values className="nickname">닉네임</Values>
               <Values className="email">email</Values>
+              <Values className="returnAt">복구예정일</Values>
               <Values className="subscription">가입일</Values>
               <Values className="reviewCount">리뷰 수</Values>
               <Values className="reportCount">신고 수</Values>
@@ -95,6 +102,7 @@ export default function Users() {
                     <Values className="accountStatus">{data.accountStatus}</Values>
                     <Values className="nickname">{data.nickname}</Values>
                     <Values className="email">{data.email}</Values>
+                    <Values className="returnAt">{data.returnAt}</Values>
                     <Values className="subscription">{data.subscription}</Values>
                     <Values className="reviewCount">{data.reviewCount}</Values>
                     <Values className="reportCount">{data.reportCount}</Values>
@@ -251,6 +259,9 @@ const Values = styled.span`
   }
   &.email {
     width: 240px;
+  }
+  &.returnAt {
+    width: 120px;
   }
   &.subscription {
     width: 120px;


### PR DESCRIPTION
<img width="700" alt="image" src="https://user-images.githubusercontent.com/115776596/224635049-f108d148-667f-417a-a1ff-70f96d90e317.png"> 

## 1. 전체회원관리 화면구현을 완료하였습니다.
   ### - 반응형 구현 모습은 신고리뷰관리와 같습니다.
   ### - 정지상태의 계정일 경우 계정 정보가 회색으로 나타납니다.

 ## 2. 3.13 스탠드업의 피드백을 반영하였습니다.
   ### - 계정 정지기간 옵션은 3가지 입니다. (3일, 7일, 30일)
   ### - 모든 계정의 상태를 확인할 수 있습니다. (active, suspended)
   ### - 계정의 복구예정일을 확인할 수 있습니다.
   ### - 계정복구버튼이 추가되었습니다.
   ### - semantic tags 로 수정하였습니다.

 ## 3. 3.13 FE 멘토링의 피드백을 반영하였습니다.
   ### - semantic tags 로 수정하였습니다.