### PR TITLE
FE_fix/pharmDetail

### DIFF
--- a/front/src/Components/Modal/AnyDropDown.tsx
+++ b/front/src/Components/Modal/AnyDropDown.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { zIndex_Modal } from "../../Util/z-index";
 import { GrClose } from "react-icons/gr";
 
 interface Props {
@@ -48,7 +49,6 @@ export default function AnyDropDown({ setIsDropDownDown }: Props) {
 }
 
 const DropDownContainer = styled.section`
-  z-index: 10;
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -61,6 +61,7 @@ const DropDownContainer = styled.section`
   background: white;
   box-shadow: var(--bs-lg);
   border-radius: 3px;
+  z-index: ${zIndex_Modal.AnyDropDown};
 `;
 const CloseBtnContainer = styled.header`
   cursor: pointer;

--- a/front/src/Components/Modal/AnyDropDown.tsx
+++ b/front/src/Components/Modal/AnyDropDown.tsx
@@ -10,7 +10,7 @@ export default function AnyDropDown({ setIsDropDownDown }: Props) {
   return (
     <DropDownContainer onClick={(event) => event.stopPropagation()}>
       <CloseBtnContainer>
-        <GrClose id="close" onClick={() => setIsDropDownDown(false)} />
+        <GrClose id="close" onClick={() => setIsDropDownDown(false)} aria-hidden={true}/>
       </CloseBtnContainer>
       <Unit>
         <Key>월요일</Key>

--- a/front/src/Components/Modal/AnyDropDown.tsx
+++ b/front/src/Components/Modal/AnyDropDown.tsx
@@ -1,0 +1,94 @@
+import styled from "styled-components";
+import { GrClose } from "react-icons/gr";
+
+interface Props {
+  setIsDropDownDown: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export default function AnyDropDown({ setIsDropDownDown }: Props) {
+  return (
+    <DropDownContainer onClick={(event) => event.stopPropagation()}>
+      <CloseBtnContainer>
+        <GrClose id="close" onClick={() => setIsDropDownDown(false)} />
+      </CloseBtnContainer>
+      <Unit>
+        <Key>월요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>화요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>수요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>목요일</Key>
+        <Value>둘째, 넷째주 휴무</Value>
+      </Unit>
+      <Unit>
+        <Key>금요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>토요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>일요일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+      <Unit>
+        <Key>공휴일</Key>
+        <Value>10:00 - 20:00</Value>
+      </Unit>
+    </DropDownContainer>
+  );
+}
+
+const DropDownContainer = styled.section`
+  z-index: 10;
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 8px 0;
+  bottom: 5px;
+  right: 15px;
+  gap: 3px;
+  background: white;
+  box-shadow: var(--bs-lg);
+  border-radius: 3px;
+`;
+const CloseBtnContainer = styled.header`
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 7px;
+  margin-bottom: 2px;
+  height: 15px;
+  width: 146px;
+  font-size: 15px;
+  color: var(--black-100);
+  &#close:hover {
+    color: var(--black-600);
+  }
+`;
+const Unit = styled.article`
+  display: flex;
+  align-items: center;
+`;
+const Key = styled.h5`
+  width: 45px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-left: 7px;
+  color: var(--black-500);
+`;
+const Value = styled.span`
+  font-weight: 400;
+  font-size: 14px;
+  font-weight: 400;
+`;

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -1,4 +1,3 @@
-//! 모달 컴포넌트 본 창입니다
 import { useState } from "react";
 import styled from "styled-components";
 import PharmInfo from "./PharmInfo";
@@ -6,21 +5,25 @@ import ReviewUnit from "./ReviewUnit";
 import WriteReviewForm from "./WriteReviewForm";
 import PharmRank from "../Ul/PharmRank";
 import Button from "../Ul/Button";
+import { GrClose } from "react-icons/gr";
+import { link } from "fs";
 
 interface Props {
-  isModalUp: boolean;
   setIsModalUp: React.Dispatch<React.SetStateAction<boolean>>;
   like: boolean;
   setLike: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function PharmDetail({ isModalUp, setIsModalUp, like, setLike }: Props) {
+export default function PharmDetail({ setIsModalUp, like, setLike }: Props) {
   const [isReviewFormShown, setIsReviewFormShown] = useState(false);
 
   return (
     <>
-      <ModalBackDrop onClick={() => setIsModalUp(!isModalUp)}>
+      <ModalBackDrop onClick={() => setIsModalUp(false)}>
         <ModalContainer onClick={(event) => event.stopPropagation()}>
+          <CloseBtnContainer>
+            <GrClose id="close" onClick={() => setIsModalUp(false)} />
+          </CloseBtnContainer>
           <InfoHeader>
             <InfoTitle>킹갓약국</InfoTitle>
             <PharmRank />
@@ -33,27 +36,20 @@ export default function PharmDetail({ isModalUp, setIsModalUp, like, setLike }: 
                 <ReviewUnit />
               </Reviews>
             </ReviewContainer>
-            {isReviewFormShown ? (
-              <WriteReviewForm isReviewFormShown={isReviewFormShown} setIsReviewFormShown={setIsReviewFormShown} />
-            ) : null}
-            {isReviewFormShown ? null : (
-              <WriteReviewBtnContainer>
-                <Button
-                  onClick={() => setIsReviewFormShown(!isReviewFormShown)}
-                  color="mint"
-                  size="md"
-                  text="리뷰쓰기"
-                />
-              </WriteReviewBtnContainer>
-            )}
           </Constant>
+          {isReviewFormShown ? <WriteReviewForm setIsReviewFormShown={setIsReviewFormShown} /> : null}
+          {isReviewFormShown ? null : (
+            <WriteReviewBtnContainer>
+              <Button onClick={() => setIsReviewFormShown(true)} color="mint" size="md" text="리뷰쓰기" />
+            </WriteReviewBtnContainer>
+          )}
         </ModalContainer>
       </ModalBackDrop>
     </>
   );
 }
 
-const ModalBackDrop = styled.div`
+const ModalBackDrop = styled.main`
   z-index: 1;
   position: fixed;
   display: flex;
@@ -65,14 +61,14 @@ const ModalBackDrop = styled.div`
   left: 0;
   background-color: var(--modal-backdrop);
 `;
-const ModalContainer = styled.div`
+const ModalContainer = styled.section`
   position: relative;
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
   top: 30px;
-  height: 600px;
+  height: 700px;
   width: 940px;
   background-color: var(--white);
   border-radius: 10px;
@@ -85,40 +81,6 @@ const ModalContainer = styled.div`
     width: 500px;
     background-color: var(--white);
     border-radius: 10px;
-  }
-  position: relative;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  height: 600px;
-  width: 940px;
-  background-color: var(--white);
-  border-radius: 10px;
-  @media (max-width: 768px) {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding-bottom: 20px;
-    height: 700px;
-    width: 500px;
-    background-color: var(--white);
-    border-radius: 10px;
-  }
-`;
-const Constant = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  @media (max-width: 768px) {
-    flex-direction: column;
-    overflow-y: scroll;
-    height: 580px;
-    padding-top: calc(100% - 180px);
-  }
-  ::-webkit-scrollbar-track {
-    background-color: var(--black-075);
-    border-radius: 0px 5px 5px 0px;
   }
 `;
 const InfoHeader = styled.header`
@@ -134,7 +96,35 @@ const InfoHeader = styled.header`
     border-bottom: 1px solid var(--black-100);
   }
 `;
-const InfoTitle = styled.div`
+const Constant = styled.section`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  ::-webkit-scrollbar-track {
+    background-color: var(--black-075);
+    border-radius: 0px 5px 5px 0px;
+  }
+  @media (max-width: 768px) {
+    display: block;
+    overflow-y: scroll;
+  }
+`;
+const WriteReviewBtnContainer = styled.footer`
+  position: absolute;
+  display: flex;
+  justify-content: flex-end;
+  right: 20px;
+  bottom: 25px;
+  width: 450px;
+  padding-top: 10px;
+  background-color: var(--white);
+  @media (max-width: 768px) {
+    position: static;
+    bottom: 20px;
+    background-color: var(--white);
+  }
+`;
+const InfoTitle = styled.h1`
   font-weight: bold;
   font-size: 30px;
   @media (max-width: 768px) {
@@ -146,7 +136,7 @@ const ReviewContainer = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  height: 550px;
+  height: 600px;
   width: 450px;
   padding: 10px 0px 0px 20px;
   @media (max-width: 768px) {
@@ -155,34 +145,29 @@ const ReviewContainer = styled.main`
     align-items: center;
     height: auto;
     padding: 20px 10px 10px 10px;
-    margin-bottom: 60px;
     border-bottom: 1px solid var(--black-100);
   }
 `;
-const ReviewTitle = styled.div`
+const ReviewTitle = styled.h2`
   padding-bottom: 10px;
-  border-bottom: 1px solid var(--black-100);
-  color: var(--black-500);
-  font-weight: bold;
   font-size: 25px;
+  font-weight: bold;
+  color: var(--black-500);
+  border-bottom: 1px solid var(--black-100);
   @media (max-width: 768px) {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    width: 450px;
     padding-left: 10px;
     gap: 100px;
+    width: 450px;
   }
 `;
-const Reviews = styled.div`
+const Reviews = styled.section`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   overflow-y: scroll;
-  border-bottom: 0.5px solid var(--black-100);
-  ::-webkit-scrollbar-track {
-    visibility: hidden;
-  }
   :active::-webkit-scrollbar-track {
     width: 0.6rem;
     visibility: visible;
@@ -192,20 +177,15 @@ const Reviews = styled.div`
     overflow: visible;
   }
 `;
-const WriteReviewBtnContainer = styled.span`
-  z-index: 2;
+const CloseBtnContainer = styled.div`
+  cursor: pointer;
+  z-index: 1000;
   position: absolute;
   display: flex;
   justify-content: flex-end;
+  top: 20px;
   right: 20px;
-  bottom: 25px;
-  width: 450px;
-  padding-top: 10px;
-  background-color: var(--white);
-  @media (max-width: 768px) {
-    z-index: 2;
-    bottom: 20px;
-    background-color: var(--white);
-    width: 480px;
-  }
+  width: 500px;
+  font-size: 30px;
+  color: var(--black-100);
 `;

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -22,7 +22,7 @@ export default function PharmDetail({ setIsModalUp, like, setLike }: Props) {
       <ModalBackDrop onClick={() => setIsModalUp(false)}>
         <ModalContainer onClick={(event) => event.stopPropagation()}>
           <CloseBtnContainer>
-            <GrClose id="close" onClick={() => setIsModalUp(false)} />
+            <GrClose id="close" onClick={() => setIsModalUp(false)} aria-hidden="true"/>
           </CloseBtnContainer>
           <InfoHeader>
             <InfoTitle>킹갓약국</InfoTitle>

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -5,8 +5,8 @@ import ReviewUnit from "./ReviewUnit";
 import WriteReviewForm from "./WriteReviewForm";
 import PharmRank from "../Ul/PharmRank";
 import Button from "../Ul/Button";
+import { zIndex_Modal } from "../../Util/z-index";
 import { GrClose } from "react-icons/gr";
-import { link } from "fs";
 
 interface Props {
   setIsModalUp: React.Dispatch<React.SetStateAction<boolean>>;
@@ -34,6 +34,13 @@ export default function PharmDetail({ setIsModalUp, like, setLike }: Props) {
               <ReviewTitle>리뷰</ReviewTitle>
               <Reviews>
                 <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
+                <ReviewUnit />
               </Reviews>
             </ReviewContainer>
           </Constant>
@@ -50,7 +57,6 @@ export default function PharmDetail({ setIsModalUp, like, setLike }: Props) {
 }
 
 const ModalBackDrop = styled.main`
-  z-index: 1;
   position: fixed;
   display: flex;
   justify-content: center;
@@ -60,6 +66,7 @@ const ModalBackDrop = styled.main`
   top: 0;
   left: 0;
   background-color: var(--modal-backdrop);
+  z-index: ${zIndex_Modal.ModalBackDrop};
 `;
 const ModalContainer = styled.section`
   position: relative;
@@ -82,6 +89,7 @@ const ModalContainer = styled.section`
     background-color: var(--white);
     border-radius: 10px;
   }
+  z-index: ${zIndex_Modal.ModalContainer};
 `;
 const InfoHeader = styled.header`
   display: none;
@@ -179,7 +187,6 @@ const Reviews = styled.section`
 `;
 const CloseBtnContainer = styled.div`
   cursor: pointer;
-  z-index: 1000;
   position: absolute;
   display: flex;
   justify-content: flex-end;
@@ -188,4 +195,5 @@ const CloseBtnContainer = styled.div`
   width: 500px;
   font-size: 30px;
   color: var(--black-100);
+  z-index: ${zIndex_Modal.CloseBtnContainer};
 `;

--- a/front/src/Components/Modal/PharmInfo.tsx
+++ b/front/src/Components/Modal/PharmInfo.tsx
@@ -21,7 +21,7 @@ export default function PharmInfo({ like, setLike }: Props) {
       <InfoImgContainer>
         <Img src="./Images/random.png" alt="고심약국"></Img>
         <LikeButton onClick={() => setLike(!like)}>
-          {like ? <img src="./Images/Heart.png" /> : <img src="./Images/UnHeart.png" />}
+          {like ? <img src="./Images/Heart.png" alt="like"/> : <img src="./Images/UnHeart.png" alt="unlike"/>}
         </LikeButton>
       </InfoImgContainer>
       <InfoInfo>

--- a/front/src/Components/Modal/PharmInfo.tsx
+++ b/front/src/Components/Modal/PharmInfo.tsx
@@ -60,7 +60,6 @@ export default function PharmInfo({ like, setLike }: Props) {
 }
 
 const InfoContainer = styled.aside`
-  /* z-index: 1; */
   position: relative;
   display: flex;
   flex-direction: column;
@@ -165,6 +164,7 @@ const InfoTagContainer = styled.section`
 `;
 const InfoTagTitle = styled.h3`
   font-size: 14px;
+  font-weight: 400;
   color: var(--black-500);
 `;
 const InfoTagBox = styled.section`
@@ -185,6 +185,7 @@ const More = styled.button`
   font-size: 12px;
   border-radius: 15px;
   border: 1px solid var(--l_button-mint);
+  background-color: transparent;
   :hover {
     color: var(--l_button-mint-hover);
     border: 1px solid var(--l_button-mint-hover);

--- a/front/src/Components/Modal/PharmInfo.tsx
+++ b/front/src/Components/Modal/PharmInfo.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import Tag from "../Ul/Tag";
 import PharmRank from "../Ul/PharmRank";
+import AnyDropDown from "./AnyDropDown";
 
 interface Props {
   like: boolean;
@@ -10,6 +11,7 @@ interface Props {
 }
 
 export default function PharmInfo({ like, setLike }: Props) {
+  const [isDropDownDown, setIsDropDownDown] = useState(false);
   return (
     <InfoContainer>
       <InfoHeader>
@@ -33,7 +35,15 @@ export default function PharmInfo({ like, setLike }: Props) {
         </InfoUnit>
         <InfoUnit>
           <InfoInfoTitle>영업시간</InfoInfoTitle>
-          <InfoInfoContent>09:00 ~ 21:00</InfoInfoContent>
+          <InfoInfoContent>
+            09:00 ~ 21:00
+            {!isDropDownDown ? (
+              <More id={`dropDown ${isDropDownDown ? "close" : "open"}`} onClick={() => setIsDropDownDown(true)}>
+                영업시간 더보기
+              </More>
+            ) : null}
+            {isDropDownDown ? <AnyDropDown setIsDropDownDown={setIsDropDownDown} /> : null}
+          </InfoInfoContent>
         </InfoUnit>
       </InfoInfo>
       <InfoTagContainer>
@@ -50,11 +60,11 @@ export default function PharmInfo({ like, setLike }: Props) {
 }
 
 const InfoContainer = styled.aside`
-  z-index: 1;
+  /* z-index: 1; */
+  position: relative;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 550px;
   width: 450px;
   padding: 10px 20px 0px 0px;
   border-right: 1px solid var(--black-100);
@@ -71,26 +81,26 @@ const InfoHeader = styled.header`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0px 10px 7px 10px;
+  padding: 10px 10px 10px 10px;
   gap: 10px;
   border-bottom: 1px solid var(--black-100);
   @media (max-width: 768px) {
     display: none;
   }
 `;
-const InfoTitle = styled.div`
+const InfoTitle = styled.h1`
   font-weight: bold;
   font-size: 30px;
   @media (max-width: 768px) {
     margin-top: 30px;
   }
 `;
-const InfoImgContainer = styled.div`
+const InfoImgContainer = styled.section`
   position: relative;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 10px 5px;
+  padding: 20px 5px;
   border-bottom: 1px solid var(--black-100);
 `;
 const Img = styled.img`
@@ -99,59 +109,65 @@ const Img = styled.img`
   height: 15.625rem;
   border-radius: 5px;
 `;
-const LikeButton = styled.span`
+const LikeButton = styled.button`
   position: absolute;
   right: 51px;
-  top: 12px;
+  top: 22px;
   width: 20px;
+  border: none;
+  background-color: transparent;
   @media (max-width: 768px) {
     right: 60px;
-    top: 11px;
+    top: 21px;
   }
 `;
-const InfoInfo = styled.div`
+const InfoInfo = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 10px;
-  gap: 5px;
+  padding: 20px 10px;
+  gap: 10px;
   border-bottom: 1px solid var(--black-100);
   @media (max-width: 768px) {
     padding: 20px;
   }
 `;
-const InfoUnit = styled.div`
+const InfoUnit = styled.article`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
   gap: 20px;
 `;
-const InfoInfoTitle = styled.span`
+const InfoInfoTitle = styled.h2`
+  width: 70px;
   color: var(--black-350);
-  font-size: 17px;
+  font-size: 20px;
   font-weight: bold;
 `;
 const InfoInfoContent = styled.span`
-  font-size: 16px;
+  display: flex;
+  align-items: center;
+  height: 25px;
+  gap: 3px;
+  font-size: 18px;
 `;
-const InfoTagContainer = styled.div`
+const InfoTagContainer = styled.section`
   display: flex;
   flex-direction: column;
-  padding: 10px;
+  padding: 20px 10px;
   gap: 5px;
-  border-bottom: 1px solid var(--black-100);
   @media (max-width: 768px) {
     gap: 10px;
     padding: 20px;
     border: none;
   }
 `;
-const InfoTagTitle = styled.div`
+const InfoTagTitle = styled.h3`
   font-size: 14px;
   color: var(--black-500);
 `;
-const InfoTagBox = styled.div`
+const InfoTagBox = styled.section`
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 5px;
@@ -159,4 +175,18 @@ const InfoTagBox = styled.div`
   gap: 5px;
   border-radius: 5px;
   box-shadow: 0px 0px 5px 0.5px var(--black-100) inset;
+`;
+const More = styled.button`
+  cursor: pointer;
+  display: inline-block;
+  color: var(--l_button-mint);
+  margin-left: 5px;
+  padding: 3px 5px;
+  font-size: 12px;
+  border-radius: 15px;
+  border: 1px solid var(--l_button-mint);
+  :hover {
+    color: var(--l_button-mint-hover);
+    border: 1px solid var(--l_button-mint-hover);
+  }
 `;

--- a/front/src/Components/Modal/ReviewUnit.tsx
+++ b/front/src/Components/Modal/ReviewUnit.tsx
@@ -45,7 +45,7 @@ export default function ReviewUnit() {
             <Upper>
               <UserInfo>
                 <span id="reply">
-                  <BsArrowReturnRight />
+                  <BsArrowReturnRight aria-hidden="true"/>
                 </span>
                 <UserIcon src="/Images/Pharm.png" />
                 <UserName>킹갓 약사</UserName>

--- a/front/src/Components/Modal/ReviewUnit.tsx
+++ b/front/src/Components/Modal/ReviewUnit.tsx
@@ -79,7 +79,6 @@ export default function ReviewUnit() {
 }
 
 const ReviewUnitContainer = styled.article`
-  z-index: 1;
   position: relative;
   display: flex;
   flex-direction: column;

--- a/front/src/Components/Modal/ReviewUnit.tsx
+++ b/front/src/Components/Modal/ReviewUnit.tsx
@@ -10,243 +10,70 @@ export default function ReviewUnit() {
 
   return (
     <>
-    <ReviewUnitContainer>
-      <section>
-        <Upper>
-          <UserInfo>
-            <UserIcon src="/Images/User.png" />
-            <UserName>caffeine</UserName>
-            <Created>2023.03.05</Created>
-          </UserInfo>
-          <ButtonContainer>
-            {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-            <Button color="l_mint" size="sm" text="댓 글" onClick={() => setIsCommentFormShown(!isCommentFormShown)} />
-            <Button color="l_black" size="sm" text="신 고" />
-          </ButtonContainer>
-        </Upper>
-        <Lower>
-          <Rest>
-            <ReviewText>쌍화탕은 하나씩 주시는데 약사선생님은 바쁘신지 불친절합니다.</ReviewText>
-            <ReviewTagContainer>
-              <Tag idx={0} />
-              <Tag idx={1} />
-              <Tag idx={2} />
-              <Tag idx={3} />
-            </ReviewTagContainer>
-          </Rest>
-          <ReviewImg src="./Images/쌍화탕.jpg" />
-        </Lower>
-        <CommentContainer>
+      <ReviewUnitContainer>
+        <section>
           <Upper>
             <UserInfo>
-              <span id="reply">
-                <BsArrowReturnRight />
-              </span>
-              <UserIcon src="/Images/Pharm.png" />
-              <UserName>킹갓 약사</UserName>
+              <UserIcon src="/Images/User.png" />
+              <UserName>caffeine</UserName>
               <Created>2023.03.05</Created>
             </UserInfo>
             <ButtonContainer>
               {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
               <Button
-                color="l_blue"
+                color="l_mint"
                 size="sm"
-                text="수 정"
-                onClick={() => setIsCommentFormShown(!isCommentFormShown)}
+                text="댓 글"
+                onClick={() => setIsCommentFormShown(true)}
               />
-              <Button color="l_red" size="sm" text="삭 제 " />
+              <Button color="l_black" size="sm" text="신 고" />
             </ButtonContainer>
           </Upper>
-          <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
-        </CommentContainer>
-      </section>
-      {isCommentFormShown ? (
-        <WriteCommentForm>
-          <Instruction>
-            <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
-          </Instruction>
-          <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
-        </WriteCommentForm>
-      ) : null}
-    </ReviewUnitContainer>
-    <ReviewUnitContainer>
-      <section>
-        <Upper>
-          <UserInfo>
-            <UserIcon src="/Images/User.png" />
-            <UserName>caffeine</UserName>
-            <Created>2023.03.05</Created>
-          </UserInfo>
-          <ButtonContainer>
-            {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-            <Button color="l_mint" size="sm" text="댓 글" onClick={() => setIsCommentFormShown(!isCommentFormShown)} />
-            <Button color="l_black" size="sm" text="신 고" />
-          </ButtonContainer>
-        </Upper>
-        <Lower>
-          <Rest>
-            <ReviewText>쌍화탕은 하나씩 주시는데 약사선생님은 바쁘신지 불친절합니다.</ReviewText>
-            <ReviewTagContainer>
-              <Tag idx={0} />
-              <Tag idx={1} />
-              <Tag idx={2} />
-              <Tag idx={3} />
-            </ReviewTagContainer>
-          </Rest>
-          <ReviewImg src="./Images/쌍화탕.jpg" />
-        </Lower>
-        <CommentContainer>
-          <Upper>
-            <UserInfo>
-              <span id="reply">
-                <BsArrowReturnRight />
-              </span>
-              <UserIcon src="/Images/Pharm.png" />
-              <UserName>킹갓 약사</UserName>
-              <Created>2023.03.05</Created>
-            </UserInfo>
-            <ButtonContainer>
-              {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-              <Button
-                color="l_blue"
-                size="sm"
-                text="수 정"
-                onClick={() => setIsCommentFormShown(!isCommentFormShown)}
-              />
-              <Button color="l_red" size="sm" text="삭 제 " />
-            </ButtonContainer>
-          </Upper>
-          <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
-        </CommentContainer>
-      </section>
-      {isCommentFormShown ? (
-        <WriteCommentForm>
-          <Instruction>
-            <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
-          </Instruction>
-          <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
-        </WriteCommentForm>
-      ) : null}
-    </ReviewUnitContainer>
-    <ReviewUnitContainer>
-      <section>
-        <Upper>
-          <UserInfo>
-            <UserIcon src="/Images/User.png" />
-            <UserName>caffeine</UserName>
-            <Created>2023.03.05</Created>
-          </UserInfo>
-          <ButtonContainer>
-            {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-            <Button color="l_mint" size="sm" text="댓 글" onClick={() => setIsCommentFormShown(!isCommentFormShown)} />
-            <Button color="l_black" size="sm" text="신 고" />
-          </ButtonContainer>
-        </Upper>
-        <Lower>
-          <Rest>
-            <ReviewText>쌍화탕은 하나씩 주시는데 약사선생님은 바쁘신지 불친절합니다.</ReviewText>
-            <ReviewTagContainer>
-              <Tag idx={0} />
-              <Tag idx={1} />
-              <Tag idx={2} />
-              <Tag idx={3} />
-            </ReviewTagContainer>
-          </Rest>
-          <ReviewImg src="./Images/쌍화탕.jpg" />
-        </Lower>
-        <CommentContainer>
-          <Upper>
-            <UserInfo>
-              <span id="reply">
-                <BsArrowReturnRight />
-              </span>
-              <UserIcon src="/Images/Pharm.png" />
-              <UserName>킹갓 약사</UserName>
-              <Created>2023.03.05</Created>
-            </UserInfo>
-            <ButtonContainer>
-              {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-              <Button
-                color="l_blue"
-                size="sm"
-                text="수 정"
-                onClick={() => setIsCommentFormShown(!isCommentFormShown)}
-              />
-              <Button color="l_red" size="sm" text="삭 제 " />
-            </ButtonContainer>
-          </Upper>
-          <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
-        </CommentContainer>
-      </section>
-      {isCommentFormShown ? (
-        <WriteCommentForm>
-          <Instruction>
-            <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
-          </Instruction>
-          <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
-        </WriteCommentForm>
-      ) : null}
-    </ReviewUnitContainer>
-    <ReviewUnitContainer>
-      <section>
-        <Upper>
-          <UserInfo>
-            <UserIcon src="/Images/User.png" />
-            <UserName>caffeine</UserName>
-            <Created>2023.03.05</Created>
-          </UserInfo>
-          <ButtonContainer>
-            {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-            <Button color="l_mint" size="sm" text="댓 글" onClick={() => setIsCommentFormShown(!isCommentFormShown)} />
-            <Button color="l_black" size="sm" text="신 고" />
-          </ButtonContainer>
-        </Upper>
-        <Lower>
-          <Rest>
-            <ReviewText>쌍화탕은 하나씩 주시는데 약사선생님은 바쁘신지 불친절합니다.</ReviewText>
-            <ReviewTagContainer>
-              <Tag idx={0} />
-              <Tag idx={1} />
-              <Tag idx={2} />
-              <Tag idx={3} />
-            </ReviewTagContainer>
-          </Rest>
-          <ReviewImg src="./Images/쌍화탕.jpg" />
-        </Lower>
-        <CommentContainer>
-          <Upper>
-            <UserInfo>
-              <span id="reply">
-                <BsArrowReturnRight />
-              </span>
-              <UserIcon src="/Images/Pharm.png" />
-              <UserName>킹갓 약사</UserName>
-              <Created>2023.03.05</Created>
-            </UserInfo>
-            <ButtonContainer>
-              {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
-              <Button
-                color="l_blue"
-                size="sm"
-                text="수 정"
-                onClick={() => setIsCommentFormShown(!isCommentFormShown)}
-              />
-              <Button color="l_red" size="sm" text="삭 제 " />
-            </ButtonContainer>
-          </Upper>
-          <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
-        </CommentContainer>
-      </section>
-      {isCommentFormShown ? (
-        <WriteCommentForm>
-          <Instruction>
-            <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
-          </Instruction>
-          <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
-        </WriteCommentForm>
-      ) : null}
-    </ReviewUnitContainer>
-
+          <Lower>
+            <Rest>
+              <ReviewText>쌍화탕은 하나씩 주시는데 약사선생님은 바쁘신지 불친절합니다.</ReviewText>
+              <ReviewTagContainer>
+                <Tag idx={0} />
+                <Tag idx={1} />
+                <Tag idx={2} />
+                <Tag idx={3} />
+              </ReviewTagContainer>
+            </Rest>
+            <ReviewImg src="./Images/쌍화탕.jpg" />
+          </Lower>
+          <CommentContainer>
+            <Upper>
+              <UserInfo>
+                <span id="reply">
+                  <BsArrowReturnRight />
+                </span>
+                <UserIcon src="/Images/Pharm.png" />
+                <UserName>킹갓 약사</UserName>
+                <Created>2023.03.05</Created>
+              </UserInfo>
+              <ButtonContainer>
+                {/* 약사계정이면 댓글 버튼이 보이고, 아닌경우에는 안보이는 로직 작성 필요 */}
+                <Button
+                  color="l_blue"
+                  size="sm"
+                  text="수 정"
+                  onClick={() => setIsCommentFormShown(true)}
+                />
+                <Button color="l_red" size="sm" text="삭 제 " />
+              </ButtonContainer>
+            </Upper>
+            <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
+          </CommentContainer>
+        </section>
+        {isCommentFormShown ? (
+          <WriteCommentForm>
+            <Instruction>
+              <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
+            </Instruction>
+            <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
+          </WriteCommentForm>
+        ) : null}
+      </ReviewUnitContainer>
     </>
   );
 }
@@ -256,7 +83,7 @@ const ReviewUnitContainer = styled.article`
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 15px 0px 10px 10px;
+  padding: 15px 10px 10px 10px;
   border-bottom: 1px solid var(--black-100);
   @media (max-width: 768px) {
     position: static;
@@ -266,14 +93,14 @@ const ReviewUnitContainer = styled.article`
     width: 420px;
   }
 `;
-const Upper = styled.div`
+const Upper = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
   padding-bottom: 5px;
 `;
-const UserInfo = styled.span`
+const UserInfo = styled.header`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -283,10 +110,11 @@ const UserInfo = styled.span`
   }
 `;
 const UserIcon = styled.img`
+  object-fit: cover;
   width: 20px;
   height: 20px;
-  object-fit: cover;
   border-radius: 50%;
+  border: 2px solid var(--blue-100);
 `;
 const UserName = styled.span`
   font-size: 15px;
@@ -300,23 +128,23 @@ const ButtonContainer = styled.span`
   gap: 5px;
   font-size: 10px;
 `;
-const Lower = styled.div`
+const Lower = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
 `;
-const Rest = styled.span`
+const Rest = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
 `;
-const ReviewText = styled.span`
+const ReviewText = styled.section`
   padding-top: 10px;
   width: 280px;
   height: 0px;
   font-size: 14px;
 `;
-const ReviewTagContainer = styled.div`
+const ReviewTagContainer = styled.section`
   display: flex;
   overflow: hidden;
   width: 280px;
@@ -329,19 +157,19 @@ const ReviewImg = styled.img`
   width: 100px;
   border-radius: 5px;
 `;
-const CommentContainer = styled.div`
+const CommentContainer = styled.section`
   display: flex;
   flex-direction: column;
-  padding: 10px 0px 0px 6px;
   margin-top: 10px;
+  padding: 10px 0px 0px 6px;
   gap: 3px;
   border-top: 1px solid var(--black-075);
 `;
 const Comment = styled.div`
   padding: 10px;
   font-size: 14px;
-  background-color: var(--black-025);
   border-radius: 5px;
+  background-color: var(--black-025);
   box-shadow: 0px 0px 5px 0.5px var(--black-100) inset;
 `;
 const WriteCommentForm = styled.section`
@@ -351,11 +179,11 @@ const WriteCommentForm = styled.section`
   padding: 10px;
   gap: 5px;
   height: 80px;
-  background-color: var(--white);
   border-radius: 10px;
+  background-color: var(--white);
   border: 0.5px solid var(--blue-300);
   box-shadow: 0px 0px 5px var(--black-200);
 `;
-const Instruction = styled.div`
+const Instruction = styled.header`
   font-size: 12px;
 `;

--- a/front/src/Components/Modal/ReviewUnit.tsx
+++ b/front/src/Components/Modal/ReviewUnit.tsx
@@ -14,7 +14,7 @@ export default function ReviewUnit() {
         <section>
           <Upper>
             <UserInfo>
-              <UserIcon src="/Images/User.png" />
+              <UserIcon src="/Images/User.png" alt="user"/>
               <UserName>caffeine</UserName>
               <Created>2023.03.05</Created>
             </UserInfo>
@@ -47,7 +47,7 @@ export default function ReviewUnit() {
                 <span id="reply">
                   <BsArrowReturnRight aria-hidden="true"/>
                 </span>
-                <UserIcon src="/Images/Pharm.png" />
+                <UserIcon src="/Images/Pharm.png" alt="pharmacist"/>
                 <UserName>킹갓 약사</UserName>
                 <Created>2023.03.05</Created>
               </UserInfo>
@@ -59,7 +59,7 @@ export default function ReviewUnit() {
                   text="수 정"
                   onClick={() => setIsCommentFormShown(true)}
                 />
-                <Button color="l_red" size="sm" text="삭 제 " />
+                <Button color="l_red" size="sm" text="삭 제" />
               </ButtonContainer>
             </Upper>
             <Comment>누가우리약국 오라고 칼들고 협박함? 다신 오지마ㅇㅇ</Comment>
@@ -70,7 +70,8 @@ export default function ReviewUnit() {
             <Instruction>
               <p>댓글을 작성해주세요. 작성 완료 시 'Enter'를 눌러주세요.</p>
             </Instruction>
-            <Input placeholder="감사합니다 :)" isValid={true} icon={true} />
+            <label htmlFor="comment of review"/>
+            <Input id="comment of review" placeholder="감사합니다 :)" isValid={true} icon={true} />
           </WriteCommentForm>
         ) : null}
       </ReviewUnitContainer>

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Textarea from "../Ul/Textarea";
 import Button from "../Ul/Button";
 import Tag from "../Ul/Tag";
+import { zIndex_Modal } from "../../Util/z-index";
 import { MdOutlineAddAPhoto } from "react-icons/md";
 import { BiPhotoAlbum } from "react-icons/bi";
 import { GrClose } from "react-icons/gr";
@@ -74,7 +75,6 @@ export default function WriteReviewForm({ setIsReviewFormShown }: Props) {
 }
 
 const WriteReviewContainer = styled.section`
-  z-index: 3;
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -87,6 +87,7 @@ const WriteReviewContainer = styled.section`
   background-color: var(--white);
   border: 0.5px solid var(--blue-300);
   box-shadow: 0px 0px 5px var(--black-200);
+  z-index: ${zIndex_Modal.WriteReviewContainer};
   .wide{
     display: flex;
     justify-content: flex-end;

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -5,13 +5,13 @@ import Button from "../Ul/Button";
 import Tag from "../Ul/Tag";
 import { MdOutlineAddAPhoto } from "react-icons/md";
 import { BiPhotoAlbum } from "react-icons/bi";
+import { GrClose } from "react-icons/gr";
 
 interface Props {
-  isReviewFormShown: boolean;
   setIsReviewFormShown: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function WriteReviewForm({ isReviewFormShown, setIsReviewFormShown }: Props) {
+export default function WriteReviewForm({ setIsReviewFormShown }: Props) {
   const [imageSrc, setImageSrc]: any = useState(null);
   const onUpload = (e: any) => {
     const file = e.target.files[0];
@@ -27,9 +27,10 @@ export default function WriteReviewForm({ isReviewFormShown, setIsReviewFormShow
   const [rate, setRate] = useState(0);
 
   return (
-    <WriteReviewContainer>
+    <WriteReviewContainer >
+      <InputTop className="wide"><GrClose className="except" onClick={() => setIsReviewFormShown(false)}/></InputTop>
       <InputTop>
-        <Textarea placeholder="무분별한 비방, 비하, 욕설은 지양해주세요 :)" isValid={true} rows={3} icon={true} />
+        <Textarea placeholder="무분별한 비방, 비하, 욕설은 지양해주세요 :)" isValid={true} rows={3} icon={false} />
         <ReviewImgContainer>
           <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
           {imageSrc ? (
@@ -66,7 +67,6 @@ export default function WriteReviewForm({ isReviewFormShown, setIsReviewFormShow
           size="md"
           text="작성완료"
           icon={true}
-          onClick={() => setIsReviewFormShown(!isReviewFormShown)}
         />
       </InputBot>
     </WriteReviewContainer>
@@ -78,16 +78,20 @@ const WriteReviewContainer = styled.section`
   position: absolute;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   right: 20px;
   bottom: 20px;
-  height: 210px;
-  width: 430px;
   padding: 15px;
-  background-color: var(--white);
+  gap: 8px;
+  width: 430px;
   border-radius: 10px;
+  background-color: var(--white);
   border: 0.5px solid var(--blue-300);
   box-shadow: 0px 0px 5px var(--black-200);
+  .wide{
+    display: flex;
+    justify-content: flex-end;
+    width: 400px;
+  }
   @media (max-width: 768px) {
     position: absolute;
     display: flex;
@@ -98,12 +102,12 @@ const WriteReviewContainer = styled.section`
     min-height: 210px;
   }
 `;
-const InputTop = styled.div`
+const InputTop = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
 `;
-const ReviewImgContainer = styled.span`
+const ReviewImgContainer = styled.section`
   display: inline-block;
   position: relative;
 `;
@@ -119,20 +123,20 @@ const ReviewImg = styled.img`
 `;
 const Instead = styled.span`
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   height: 80px;
   width: 100px;
   font-size: 40px;
-  background-color: var(--black-075);
   color: var(--white);
   border-radius: 5px;
+  background-color: var(--black-075);
 `;
 const Label = styled.label`
   position: absolute;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   bottom: 0;
   right: 0;
   height: 26px;
@@ -142,21 +146,21 @@ const Label = styled.label`
   border-radius: 50%;
   box-shadow: 0px 0px 5px 0.5px var(--black-200);
 `;
-const TagSelection = styled.div`
+const TagSelection = styled.section`
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   height: 46px;
-  padding: 10px;
+  padding: 10px 15px;
+  gap: 10px;
   border-radius: 5px;
   box-shadow: 0px 0px 5px 0.5px var(--black-100) inset;
 `;
-const InputBot = styled.div`
+const InputBot = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
 `;
-const Rating = styled.span`
+const Rating = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -169,12 +173,14 @@ const Rating = styled.span`
 `;
 const StarContainer = styled.span`
   display: flex;
+  padding: 10px;
   gap: 10px;
 `;
 const Star = styled.img`
   width: 20px;
 `;
 const RateNum = styled.span`
-  font-weight: bold;
+  margin-right: 5px;
   color: var(--black-300);
+  font-weight: bold;
 `;

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -31,14 +31,15 @@ export default function WriteReviewForm({ setIsReviewFormShown }: Props) {
     <WriteReviewContainer >
       <InputTop className="wide"><GrClose aria-hidden="true" className="except" onClick={() => setIsReviewFormShown(false)}/></InputTop>
       <InputTop>
-        <Textarea placeholder="무분별한 비방, 비하, 욕설은 지양해주세요 :)" isValid={true} rows={3} icon={false} />
+      <label htmlFor="review"/>
+        <Textarea id="review" placeholder="무분별한 비방, 비하, 욕설은 지양해주세요 :)" isValid={true} rows={3} icon={false} />
         <ReviewImgContainer>
           <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
           {imageSrc ? (
             <ReviewImg src={imageSrc} />
           ) : (
             <Instead>
-              <BiPhotoAlbum aria-hidden={true}/>
+              <BiPhotoAlbum aria-hidden="true"/>
             </Instead>
           )}
           <Label htmlFor="img">

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -29,7 +29,7 @@ export default function WriteReviewForm({ setIsReviewFormShown }: Props) {
 
   return (
     <WriteReviewContainer >
-      <InputTop className="wide"><GrClose className="except" onClick={() => setIsReviewFormShown(false)}/></InputTop>
+      <InputTop className="wide"><GrClose aria-hidden="true" className="except" onClick={() => setIsReviewFormShown(false)}/></InputTop>
       <InputTop>
         <Textarea placeholder="무분별한 비방, 비하, 욕설은 지양해주세요 :)" isValid={true} rows={3} icon={false} />
         <ReviewImgContainer>
@@ -38,11 +38,11 @@ export default function WriteReviewForm({ setIsReviewFormShown }: Props) {
             <ReviewImg src={imageSrc} />
           ) : (
             <Instead>
-              <BiPhotoAlbum />
+              <BiPhotoAlbum aria-hidden={true}/>
             </Instead>
           )}
           <Label htmlFor="img">
-            <MdOutlineAddAPhoto />
+            <MdOutlineAddAPhoto aria-hidden="true"/>
           </Label>
         </ReviewImgContainer>
       </InputTop>

--- a/front/src/Components/PharmList/PharmItem.tsx
+++ b/front/src/Components/PharmList/PharmItem.tsx
@@ -16,7 +16,7 @@ export default function PharmItem() {
       <InfoImgContainer>
         <Img src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(true)} />
         <LikeButton onClick={() => setLike(!like)}>
-          {like ? <img src="./Images/Heart.png" /> : <img src="./Images/UnHeart.png" />}
+          {like ? <img src="./Images/Heart.png" alt="like"/> : <img src="./Images/UnHeart.png" alt="unlike"/>}
         </LikeButton>
       </InfoImgContainer>
       <PharmTitleBox>

--- a/front/src/Components/PharmList/PharmItem.tsx
+++ b/front/src/Components/PharmList/PharmItem.tsx
@@ -11,16 +11,16 @@ export default function PharmItem() {
   return (
     <PharmCard>
       {isModalUp ? (
-        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
       ) : null}
       <InfoImgContainer>
-        <Img src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(!isModalUp)} />
+        <Img src="./Images/random.png" alt="고심약국" onClick={() => setIsModalUp(true)} />
         <LikeButton onClick={() => setLike(!like)}>
           {like ? <img src="./Images/Heart.png" /> : <img src="./Images/UnHeart.png" />}
         </LikeButton>
       </InfoImgContainer>
       <PharmTitleBox>
-        <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓 약국</PharmName>
+        <PharmName onClick={() => setIsModalUp(true)}>킹갓 약국</PharmName>
         <PharmRank />
       </PharmTitleBox>
       <TagContainer>
@@ -34,7 +34,7 @@ export default function PharmItem() {
 }
 
 //약국카드
-const PharmCard = styled.div`
+const PharmCard = styled.article`
   width: 25rem;
   height: 25rem;
   display: flex;
@@ -72,21 +72,17 @@ const LikeButton = styled.span`
   right: 36px;
   top: 12px;
   width: 20px;
-  @media (max-width: 768px) {
-    right: 60px;
-    top: 11px;
-  }
 `;
 
 //약국 타이틀
-const PharmTitleBox = styled.div`
+const PharmTitleBox = styled.header`
   display: flex;
   justify-content: space-between;
   margin-top: 15px;
   padding: 0 15px;
 `;
 
-const PharmName = styled.div`
+const PharmName = styled.h1`
   cursor: pointer;
   font-size: 1.56rem;
   font-weight: bold;

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -1,7 +1,9 @@
 //홈화면 옆에 약국 리스트
 import styled from "styled-components";
 import PharmItem from "./PharmItem";
+import { zIndex_PharmList } from "../../Util/z-index";
 import { BsSearch } from "react-icons/bs";
+import { useState } from "react";
 
 //데이터 들어오면 map으로 돌리기전에 하드코딩으로 두개해놨음
 export default function PharmLists() {
@@ -61,12 +63,12 @@ const ListContainer = styled.aside`
   background-color: var(--white);
   box-shadow: var(--bs-lg);
   padding: 1.5rem 0 1rem 1.5rem;
-  z-index: 2;
   transition: 0.2s;
   @media (max-width: 768px) {
     transition: 0.2s;
     width: 30rem;
   }
+  z-index: ${zIndex_PharmList.ListContainer};
 `;
 const ContainerWrap = styled.div`
   display: flex;

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -21,7 +21,8 @@ export default function PharmLists() {
               <div>
                 <BsSearch className="searchIcon" aria-hidden="true"/>
               </div>
-              <SearchInput placeholder="약국 검색.." />
+              <label htmlFor="search box"/>
+              <SearchInput id="search box" placeholder="약국 검색.." />
             </SearchContainer>
             <ButtonContainer>
               <Button>

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import PharmItem from "./PharmItem";
 import { zIndex_PharmList } from "../../Util/z-index";
 import { BsSearch } from "react-icons/bs";
-import { useState } from "react";
 
 //데이터 들어오면 map으로 돌리기전에 하드코딩으로 두개해놨음
 export default function PharmLists() {
@@ -20,7 +19,7 @@ export default function PharmLists() {
           <PharmHeadContainer>
             <SearchContainer>
               <div>
-                <BsSearch className="searchIcon" />
+                <BsSearch className="searchIcon" aria-hidden="true"/>
               </div>
               <SearchInput placeholder="약국 검색.." />
             </SearchContainer>

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -3,15 +3,17 @@ import styled from "styled-components";
 import PharmItem from "./PharmItem";
 import { zIndex_PharmList } from "../../Util/z-index";
 import { BsSearch } from "react-icons/bs";
+import { useState } from "react";
 
 //데이터 들어오면 map으로 돌리기전에 하드코딩으로 두개해놨음
 export default function PharmLists() {
+  const [hidden, setHidden] = useState<boolean>(false);
   /* 조건부로 할려고 임의로 해놓은 것!
   나중에 데이터 넘어오면 바꿀것*/
 
   return (
-    <ListContainer>
-      <ContainerWrap>
+    <ListContainer className={hidden ? "hide" : ""}>
+      <ContainerWrap className={hidden ? "" : "hide"}>
         <EmptyContainer>
           <span className="partition" />
         </EmptyContainer>
@@ -19,9 +21,9 @@ export default function PharmLists() {
           <PharmHeadContainer>
             <SearchContainer>
               <div>
-                <BsSearch className="searchIcon" aria-hidden="true"/>
+                <BsSearch className="searchIcon" aria-hidden="true" />
               </div>
-              <label htmlFor="search box"/>
+              <label htmlFor="search box" />
               <SearchInput id="search box" placeholder="약국 검색.." />
             </SearchContainer>
             <ButtonContainer>
@@ -46,6 +48,19 @@ export default function PharmLists() {
             <PharmItem />
           </PharmItemContainer>
         </PharmContainer>
+        {hidden ? (
+          <EmptyContainer className="hide">
+            <ShowBtn className={hidden ? "" : "hide"} onClick={() => setHidden(false)}>
+              {"> 눌러서 열기"}
+            </ShowBtn>
+          </EmptyContainer>
+        ) : (
+          <EmptyContainer className="hide">
+            <ShowBtn className={hidden ? "hide" : ""} onClick={() => setHidden(true)}>
+              {"< 눌러서 숨기기"}
+            </ShowBtn>
+          </EmptyContainer>
+        )}
       </ContainerWrap>
     </ListContainer>
   );
@@ -54,7 +69,7 @@ export default function PharmLists() {
 //전체 컨테이너
 const ListContainer = styled.aside`
   position: absolute;
-  width: 36rem;
+  width: 38rem;
   height: calc(100vh - 50px);
   border-top: 1px solid var(--black-150);
   border-right: 1px solid var(--black-150);
@@ -64,9 +79,15 @@ const ListContainer = styled.aside`
   box-shadow: var(--bs-lg);
   padding: 1.5rem 0 1rem 1.5rem;
   transition: 0.2s;
+  &.hide {
+    transform: translate(-550px, 0px);
+  }
   @media (max-width: 768px) {
     transition: 0.2s;
-    width: 30rem;
+    width: 33rem;
+    &.hide {
+      transform: translate(-470px, 0px);
+    }
   }
   z-index: ${zIndex_PharmList.ListContainer};
 `;
@@ -81,6 +102,9 @@ const EmptyContainer = styled.div`
   flex-direction: row;
   justify-content: flex-end;
   margin-right: 36px;
+  &.hide {
+    margin-right: 0;
+  }
   .partition {
     width: 14px;
     border-radius: 7px;
@@ -89,7 +113,6 @@ const EmptyContainer = styled.div`
     transition: 0.2s;
     @media (max-width: 768px) {
       transition: 0.2s;
-      width: 4px;
     }
   }
 `;
@@ -105,6 +128,19 @@ const PharmHeadContainer = styled.header`
   @media (max-width: 768px) {
     transition: 0.2s;
     margin-right: 22px;
+  }
+`;
+const ShowBtn = styled.button`
+  background-color: transparent;
+  border: none;
+  display: flex;
+  justify-content: flex-start;
+  margin: 0 20px;
+  font-weight: 600;
+  font-size: 20px;
+  color: var(--black-200);
+  :hover {
+    color: var(--black-400);
   }
 `;
 const PharmItemContainer = styled.section`

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -50,7 +50,7 @@ export default function PharmLists() {
 }
 
 //전체 컨테이너
-const ListContainer = styled.div`
+const ListContainer = styled.aside`
   position: absolute;
   width: 36rem;
   height: calc(100vh - 50px);
@@ -91,12 +91,12 @@ const EmptyContainer = styled.div`
     }
   }
 `;
-const PharmContainer = styled.div`
+const PharmContainer = styled.main`
   display: flex;
   flex-direction: column;
   height: calc(100vh - 95px);
 `;
-const PharmHeadContainer = styled.div`
+const PharmHeadContainer = styled.header`
   margin-right: 42px;
   margin-bottom: 10px;
   transition: 0.2s;
@@ -105,7 +105,7 @@ const PharmHeadContainer = styled.div`
     margin-right: 22px;
   }
 `;
-const PharmItemContainer = styled.div`
+const PharmItemContainer = styled.section`
   overflow-y: scroll;
   height: calc(100vh - 135px);
   display: flex;
@@ -117,7 +117,7 @@ const PharmItemContainer = styled.div`
 `;
 
 //input
-const SearchContainer = styled.div`
+const SearchContainer = styled.section`
   display: flex;
   justify-content: center;
   margin: 10px 0;
@@ -147,7 +147,7 @@ const SearchInput = styled.input`
 `;
 
 //Buttons
-const ButtonContainer = styled.div`
+const ButtonContainer = styled.section`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;

--- a/front/src/Components/SignUpForm/PharmSignForms.tsx
+++ b/front/src/Components/SignUpForm/PharmSignForms.tsx
@@ -185,11 +185,9 @@ export default function PharmSignForms() {
   );
 }
 const Container = styled.section`
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
   padding: 2rem 1rem;
-  width: 40rem;
+  width: 35rem;
+  gap: 3px;
   border: 1px solid var(--black-200);
   border-top: none;
   border-bottom-left-radius: 18px;
@@ -199,14 +197,16 @@ const Container = styled.section`
 `;
 
 const Google = styled.article`
+  display: flex;
+  justify-content: center;
   padding-bottom: 1rem;
   .google_button {
+    cursor: pointer;
     height: 3.3rem;
-    width: 37.875rem;
-    border: 1px solid var(--black-200);
+    width: 33rem;
     border-radius: 10px;
     background-color: transparent;
-    cursor: pointer;
+    border: 1px solid var(--black-200);
     box-shadow: var(--bs-md);
     &:hover {
       background-color: var(--black-050);
@@ -247,7 +247,7 @@ const SignUpForm = styled.form`
     }
   }
 `;
-const InputContainer = styled.div`
+const InputContainer = styled.article`
   display: flex;
   flex-direction: row;
   margin-bottom: 0.5rem;
@@ -292,7 +292,7 @@ const ImgInput = styled.input`
   font-size: 1.1rem;
   text-overflow: ellipsis;
 `;
-const CheckContainer = styled.div`
+const CheckContainer = styled.article`
   display: flex;
   flex-direction: row;
   padding: 10px 0px 10px 5px;

--- a/front/src/Components/SignUpForm/PharmSignForms.tsx
+++ b/front/src/Components/SignUpForm/PharmSignForms.tsx
@@ -96,7 +96,7 @@ export default function PharmSignForms() {
       </Google>
       <SignUpForm onSubmit={onSubmit}>
         <InputContainer className={`email ${error.email ? "error" : "success"}`}>
-          <BsPersonCircle className="inputimage" />
+          <BsPersonCircle className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"email"}
             name={"email"}
@@ -107,7 +107,7 @@ export default function PharmSignForms() {
         </InputContainer>
         <ErrorAlert Error={error.email} ErrorText={"이메일 형식이 올바르지 않습니다."} />
         <InputContainer className={`${error.password ? "error" : "success"}`}>
-          <AiOutlineLock className="inputimage" />
+          <AiOutlineLock className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"password"}
             name={"password"}
@@ -118,7 +118,7 @@ export default function PharmSignForms() {
         </InputContainer>
         <ErrorAlert Error={error.password} ErrorText={"문자 숫자 특수문자 조합 8자 이상으로 조합해주세요."} />
         <InputContainer className={`${error.name ? "error" : "success"}`}>
-          <FaUserEdit className="inputimage" />
+          <FaUserEdit className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"text"}
             name={"name"}
@@ -129,7 +129,7 @@ export default function PharmSignForms() {
         </InputContainer>
         <ErrorAlert Error={error.name} ErrorText={"이름에는 공백이 들어갈 수 없습니다."} />
         <InputContainer>
-          <FaMapMarkerAlt className="inputimage" />
+          <FaMapMarkerAlt className="inputimage" aria-hidden="true"/>
           <SignUpInput
             readOnly
             type={"text"}
@@ -141,7 +141,7 @@ export default function PharmSignForms() {
           <PharmAddress setpSignForms={setpSignForms} />
         </InputContainer>
         <InputContainer>
-          <AiOutlineCamera className="inputimage" />
+          <AiOutlineCamera className="inputimage" aria-hidden="true"/>
           <ImgInput readOnly value={businessImg} placeholder="사업자 등록증을 올려주세요" />
           <div className="photo_upload">
             <Button color="l_blue" size="sm" text="사진업로드" onClick={onClickBusinessImg} />
@@ -158,7 +158,7 @@ export default function PharmSignForms() {
         </InputContainer>
 
         <InputContainer>
-          <AiOutlineCamera className="inputimage" />
+          <AiOutlineCamera className="inputimage" aria-hidden="true"/>
           <ImgInput readOnly value={pharmImg} placeholder="약사면허증 사진을 올려주세요" />
           <div className="photo_upload">
             <Button color="l_blue" size="sm" text="사진업로드" onClick={onClickPharmImg} />

--- a/front/src/Components/SignUpForm/PharmSignForms.tsx
+++ b/front/src/Components/SignUpForm/PharmSignForms.tsx
@@ -184,11 +184,11 @@ export default function PharmSignForms() {
     </Container>
   );
 }
-const Container = styled.div`
+const Container = styled.section`
   display: flex;
   justify-content: center;
   flex-direction: column;
-  padding: 3rem 1rem 1.5rem 1rem;
+  padding: 2rem 1rem;
   width: 40rem;
   border: 1px solid var(--black-200);
   border-top: none;
@@ -198,7 +198,7 @@ const Container = styled.div`
     0 4px 13px -3px hsla(0, 0%, 0%, 0.13);
 `;
 
-const Google = styled.div`
+const Google = styled.article`
   padding-bottom: 1rem;
   .google_button {
     height: 3.3rem;
@@ -230,7 +230,7 @@ const SignUpForm = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: center;
-
+  gap: 3px;
   .signup_button {
     background-color: var(--blue-500);
     border: none;
@@ -250,11 +250,11 @@ const SignUpForm = styled.form`
 const InputContainer = styled.div`
   display: flex;
   flex-direction: row;
-  border: 1px solid var(--black-150);
-  border-radius: 10px;
-  box-shadow: var(--bs-sm);
   margin-bottom: 0.5rem;
   padding: 0 10px;
+  border-radius: 10px;
+  box-shadow: var(--bs-sm);
+  border: 1px solid var(--black-150);
   .inputimage {
     display: flex;
     justify-content: center;
@@ -281,20 +281,21 @@ const InputContainer = styled.div`
 `;
 
 const ImgInput = styled.input`
-  width: 27rem;
-  height: 2.7rem;
   outline: none;
-  font-size: 1.1rem;
-  padding-left: 0.5rem;
-  border: none;
-  text-overflow: ellipsis;
-  color: var(--black-500);
   display: flex;
   flex-grow: 1;
+  padding-left: 0.5rem;
+  width: 27rem;
+  height: 2.7rem;
+  color: var(--black-500);
+  border: none;
+  font-size: 1.1rem;
+  text-overflow: ellipsis;
 `;
 const CheckContainer = styled.div`
   display: flex;
   flex-direction: row;
+  padding: 10px 0px 10px 5px;
   .checkbox_content {
     color: var(--black-500);
   }

--- a/front/src/Components/SignUpForm/SignUpFormTab.tsx
+++ b/front/src/Components/SignUpForm/SignUpFormTab.tsx
@@ -20,14 +20,14 @@ export default function SignUpForms({ tab, setTab }: Props) {
   );
 }
 
-const TabContainer = styled.div`
+const TabContainer = styled.section`
   display: flex;
   justify-content: center;
   width: 100%;
   padding-top: 3rem;
 `;
 
-const Tab = styled.div<{ title: string; tab: string }>`
+const Tab = styled.span<{ title: string; tab: string }>`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/front/src/Components/SignUpForm/UserSignUpForms.tsx
+++ b/front/src/Components/SignUpForm/UserSignUpForms.tsx
@@ -128,8 +128,8 @@ export default function UserSignUpForms() {
     </Container>
   );
 }
-const Container = styled.div`
-  padding: 3rem 1rem 1.5rem 1rem;
+const Container = styled.section`
+  padding: 2rem 1rem;
   width: 40rem;
   border: 1px solid var(--black-200);
   border-top: none;
@@ -138,7 +138,7 @@ const Container = styled.div`
   box-shadow: 0 1px 4px -3px hsla(0, 0%, 0%, 0.09), 0 3px 8px -3px hsla(0, 0%, 0%, 0.1),
     0 4px 13px -3px hsla(0, 0%, 0%, 0.13);
 `;
-const Google = styled.div`
+const Google = styled.article`
   padding-bottom: 1rem;
   .google_button {
     height: 3.3rem;
@@ -170,6 +170,7 @@ const SignUpForm = styled.form`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  gap: 3px;
   .signup_button {
     background-color: var(--blue-500);
     border: none;
@@ -186,14 +187,14 @@ const SignUpForm = styled.form`
     }
   }
 `;
-const InputContainer = styled.div`
+const InputContainer = styled.article`
   display: flex;
   flex-direction: row;
-  border: 1px solid var(--black-150);
   margin-bottom: 0.5rem;
+  padding: 0 10px;
   border-radius: 10px;
   box-shadow: var(--bs-sm);
-  padding: 0 10px;
+  border: 1px solid var(--black-150);
   .inputimage {
     display: flex;
     justify-content: center;
@@ -215,9 +216,10 @@ const InputContainer = styled.div`
   }
 `;
 
-const CheckContainer = styled.div`
+const CheckContainer = styled.article`
   display: flex;
   flex-direction: row;
+  padding: 10px 0px 10px 5px;
   .checkbox_content {
     color: var(--black-500);
   }

--- a/front/src/Components/SignUpForm/UserSignUpForms.tsx
+++ b/front/src/Components/SignUpForm/UserSignUpForms.tsx
@@ -130,7 +130,8 @@ export default function UserSignUpForms() {
 }
 const Container = styled.section`
   padding: 2rem 1rem;
-  width: 40rem;
+  width: 35rem;
+  gap: 3px;
   border: 1px solid var(--black-200);
   border-top: none;
   border-bottom-left-radius: 18px;
@@ -139,14 +140,16 @@ const Container = styled.section`
     0 4px 13px -3px hsla(0, 0%, 0%, 0.13);
 `;
 const Google = styled.article`
+  display: flex;
+  justify-content: center;
   padding-bottom: 1rem;
   .google_button {
+    cursor: pointer;
     height: 3.3rem;
-    width: 37.875rem;
-    border: 1px solid var(--black-200);
+    width: 33rem;
     border-radius: 10px;
     background-color: transparent;
-    cursor: pointer;
+    border: 1px solid var(--black-200);
     box-shadow: var(--bs-md);
     &:hover {
       background-color: var(--black-050);

--- a/front/src/Components/SignUpForm/UserSignUpForms.tsx
+++ b/front/src/Components/SignUpForm/UserSignUpForms.tsx
@@ -73,7 +73,7 @@ export default function UserSignUpForms() {
       </Google>
       <SignUpForm onSubmit={onSubmit}>
         <InputContainer className={`email ${error.email ? "error" : "success"}`}>
-          <BsPersonCircle className="inputimage" />
+          <BsPersonCircle className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"email"}
             name={"email"}
@@ -84,7 +84,7 @@ export default function UserSignUpForms() {
         </InputContainer>
         <ErrorAlert Error={error.email} ErrorText={"이메일 형식이 올바르지 않습니다."} />
         <InputContainer className={`${error.password ? "error" : "success"}`}>
-          <AiOutlineLock className="inputimage" />
+          <AiOutlineLock className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"password"}
             name={"password"}
@@ -95,7 +95,7 @@ export default function UserSignUpForms() {
         </InputContainer>
         <ErrorAlert Error={error.password} ErrorText={"문자 숫자 특수문자 조합 8자 이상으로 조합해주세요."} />
         <InputContainer className={`${error.name ? "error" : "success"}`}>
-          <FaUserEdit className="inputimage" />
+          <FaUserEdit className="inputimage" aria-hidden="true"/>
           <SignUpInput
             type={"text"}
             name={"name"}
@@ -106,7 +106,7 @@ export default function UserSignUpForms() {
         </InputContainer>
         <ErrorAlert Error={error.name} ErrorText={"이름에는 공백이 들어갈 수 없습니다."} />
         <InputContainer>
-          <FaMapMarkerAlt className="inputimage" />
+          <FaMapMarkerAlt className="inputimage"aria-hidden="true"/>
           <SignUpInput
             readOnly
             type={"text"}

--- a/front/src/Components/Ul/Button.tsx
+++ b/front/src/Components/Ul/Button.tsx
@@ -25,7 +25,7 @@ export default function Button({ text, icon, color, size, url, disabled, onClick
   // Button tag
   return (
     <BasicButton className={`${color} ${size}`} onClick={onClick}>
-      {icon ? <TbNotebook className="icon" /> : null}
+      {icon ? <TbNotebook className="icon" aria-hidden="true"/> : null}
       {text}
     </BasicButton>
   );

--- a/front/src/Components/Ul/Input.tsx
+++ b/front/src/Components/Ul/Input.tsx
@@ -14,7 +14,7 @@ export default function Input({ id, placeholder, value, icon, isValid, onChange 
     <StyledInput>
       {icon && (
         <div className="left icon">
-          <FaPencilAlt />
+          <FaPencilAlt aria-hidden="true"/>
         </div>
       )}
       <input

--- a/front/src/Components/Ul/PharmRank.tsx
+++ b/front/src/Components/Ul/PharmRank.tsx
@@ -11,7 +11,7 @@ export default function PharmRank() {
   return (
     <Container>
       <div>{starPoint ? <BsStarFill className="select_star" /> : <BsStar className="unSelect_star" />}</div>
-      <Star> {starPoint}/5 </Star>
+      <Star> {starPoint}<span className="rest">/5</span> </Star>
       <Selected>찜콩 45</Selected>
       <span className="partition" />
       <TotalReview> 리뷰 113</TotalReview>
@@ -44,7 +44,14 @@ const Star = styled.span`
   font-weight: bold;
   font-size: 1.3rem;
   margin-right: 1.2rem;
+  margin-left: 0.5rem;
   padding-bottom: 2px;
+  color: var(--black-700);
+  .rest{
+    margin-left: 0.2rem;
+    color: var(--black-500);
+    font-weight: 500;
+  }
 `;
 
 const Selected = styled.span`

--- a/front/src/Components/Ul/Tag.tsx
+++ b/front/src/Components/Ul/Tag.tsx
@@ -6,7 +6,7 @@ interface TagProps {
 }
 
 export default function Tag({ idx, list }: TagProps) {
-  list = ["친절한 서비스", "꼼꼼한 복약지도", "주차가능", "접근성이 좋음"];
+  list = ["친절함", "꼼꼼함", "주차가능", "접근성"];
 
   return <StyledTag>{list[idx]}</StyledTag>;
 }

--- a/front/src/Components/Ul/Textarea.tsx
+++ b/front/src/Components/Ul/Textarea.tsx
@@ -16,7 +16,7 @@ export default function Textarea({ id, placeholder, value, rows, icon, isValid, 
     <StyledInput>
       {icon && (
         <div className="left icon">
-          <FaPencilAlt />
+          <FaPencilAlt aria-hidden="true"/>
         </div>
       )}
       <textarea

--- a/front/src/Pages/Admin/Certify.tsx
+++ b/front/src/Pages/Admin/Certify.tsx
@@ -77,7 +77,7 @@ export default function Certify() {
               </BelowLable>
             ) : (
               <Instead>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 <span>약사인증요청이 없습니다.</span>
               </Instead>
             )}

--- a/front/src/Pages/Admin/ImageUp.tsx
+++ b/front/src/Pages/Admin/ImageUp.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { zIndex_AdminPage } from "../../Util/z-index";
 
 interface Props {
   isImgUp: boolean;
@@ -20,7 +21,6 @@ export default function PharmDetail({ isImgUp, setIsImgUp, imgUrl }: Props) {
 }
 
 const ModalBackDrop = styled.section`
-  z-index: 1;
   position: fixed;
   display: flex;
   justify-content: center;
@@ -30,6 +30,7 @@ const ModalBackDrop = styled.section`
   top: 0;
   left: 0;
   background-color: var(--modal-backdrop);
+  z-index: ${zIndex_AdminPage.ModalBackDrop};
 `;
 const Container = styled.div`
   display: flex;
@@ -41,6 +42,7 @@ const Container = styled.div`
     font-size: 20px;
     border-radius: 50%;
   }
+  z-index: ${zIndex_AdminPage.ModalBackDrop};
 `;
 const Img = styled.img`
   height: 600px;

--- a/front/src/Pages/Admin/ImageUp.tsx
+++ b/front/src/Pages/Admin/ImageUp.tsx
@@ -13,7 +13,7 @@ export default function PharmDetail({ isImgUp, setIsImgUp, imgUrl }: Props) {
       <ModalBackDrop onClick={() => setIsImgUp(!isImgUp)}>
         <Container>
           <span onClick={() => setIsImgUp(!isImgUp)}>닫기</span>
-          <Img src={`${imgUrl}`} onClick={(event) => event.stopPropagation()}></Img>
+          <Img src={imgUrl} onClick={(event) => event.stopPropagation()}></Img>
         </Container>
       </ModalBackDrop>
     </>

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -101,7 +101,7 @@ export default function Reports() {
               </BelowLable>
             ) : (
               <Instead>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 <span>신고된 리뷰가 없습니다.</span>
               </Instead>
             )}

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -111,7 +111,7 @@ export default function Users() {
               </BelowLable>
             ) : (
               <Instead>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 <span>가입된 회원이 없습니다.</span>
               </Instead>
             )}

--- a/front/src/Pages/FindPW.tsx
+++ b/front/src/Pages/FindPW.tsx
@@ -14,7 +14,7 @@ const [randomError, setRandomError] = useState(false)
   return (
     <Wrapper>
       <LogoContainer>
-        <img alt="logo" src="Images/Logo.png" />
+        <img alt="logo" src="Images/Logo.png"/>
         <h1>Medi-Map</h1>
       </LogoContainer>
       <Container>

--- a/front/src/Pages/FindPW.tsx
+++ b/front/src/Pages/FindPW.tsx
@@ -24,11 +24,11 @@ const [randomError, setRandomError] = useState(false)
           <p>입력시 해당 이메일로 임시 비밀번호가 전송됩니다.</p>
         </Instruction>
         <InputContainer className={randomError ? "error" : ""}>
-          <BsPersonCircle className="inputimage" />
+          <BsPersonCircle className="inputimage" aria-hidden="true"/>
           <SignUpInput type={"email"} name={"email"} placeholder={"이메일을 입력하세요."} onChange={()=>setRandomError(true)} />
         </InputContainer>
         <AlertMsg className={randomError ? "error" : ""}>
-          <AiOutlineExclamationCircle />
+          <AiOutlineExclamationCircle aria-hidden="true"/>
           유효성 검사 로직이 들어갈 자리입니다~!~!
         </AlertMsg>
         <ButtonContainer>

--- a/front/src/Pages/Login.tsx
+++ b/front/src/Pages/Login.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import styled from "styled-components";
-import { BsPersonCircle } from "react-icons/bs";
 import SignUpInput from "../Components/SignUpForm/SignUpInput";
+import { BsPersonCircle } from "react-icons/bs";
 import { AiOutlineLock } from "react-icons/ai";
 import { Link } from "react-router-dom";
 export default function Login() {
@@ -23,7 +22,7 @@ export default function Login() {
           </Google>
           <LoginForm>
             <InputContainer>
-              <BsPersonCircle className="inputimage" />
+              <BsPersonCircle className="inputimage" aria-hidden="true"/>
               <SignUpInput
                 type={"email"}
                 name={"email"}
@@ -33,7 +32,7 @@ export default function Login() {
               />
             </InputContainer>
             <InputContainer>
-              <AiOutlineLock className="inputimage" />
+              <AiOutlineLock className="inputimage" aria-hidden="true"/>
               <SignUpInput
                 type={"password"}
                 name={"password"}

--- a/front/src/Pages/Pharm/DropDown.tsx
+++ b/front/src/Pages/Pharm/DropDown.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import styled from "styled-components";
+import { zIndex_MyPage } from "../../Util/z-index";
 
 export default function DropDown() {
   return (
@@ -53,6 +53,7 @@ const DropDownContainer = styled.section`
   background: white;
   box-shadow: var(--bs-lg);
   border-radius: 3px;
+  z-index: ${zIndex_MyPage.DropDown};
   @media (max-width: 768px) {
     left: -25px
   }

--- a/front/src/Pages/Pharm/Pharmacist_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacist_Information.tsx
@@ -103,7 +103,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
     <Wrapper>
       <ImgContainer>
         <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
-        {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/Pharm.png" />}
+        {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/Pharm.png" alt="pharmacist"/>}
         <Label htmlFor="img">
           <MdOutlineAddAPhoto aria-hidden="true"/>
           사진추가하기

--- a/front/src/Pages/Pharm/Pharmacist_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacist_Information.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import styled from "styled-components";
 import { useDaumPostcodePopup } from "react-daum-postcode";
+import styled from "styled-components";
 import SignUpInput from "../../Components/SignUpForm/SignUpInput";
-import { Validate } from "../../Components/SignUpForm/Validation";
 import Button from "../../Components/Ul/Button";
+import { Validate } from "../../Components/SignUpForm/Validation";
 import { MdOutlineAddAPhoto } from "react-icons/md";
 import { AiOutlineExclamationCircle } from "react-icons/ai";
 

--- a/front/src/Pages/Pharm/Pharmacist_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacist_Information.tsx
@@ -105,7 +105,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
         <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
         {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/Pharm.png" />}
         <Label htmlFor="img">
-          <MdOutlineAddAPhoto />
+          <MdOutlineAddAPhoto aria-hidden="true"/>
           사진추가하기
         </Label>
       </ImgContainer>
@@ -128,7 +128,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
                 />
               </InputWrapper>
               <AlertMsg className={`${error.nickname ? "error" : ""}`}>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 이름에는 공백이 들어갈 수 없습니다.
               </AlertMsg>
             </EditWrapper>
@@ -173,7 +173,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.password ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />
+                  <AiOutlineExclamationCircle aria-hidden="true"/>
                   비밀번호가 일치하지 않습니다.
                 </AlertMsg>
               </EditWrapper>
@@ -191,7 +191,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.newPassword ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />
+                  <AiOutlineExclamationCircle aria-hidden="true"/>
                   문자 숫자 특수문자 조합 8자 이상으로 조합해주세요.
                 </AlertMsg>
               </EditWrapper>
@@ -209,7 +209,7 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.confirmNewPassword ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />새 비밀번호와 일치하지 않습니다.
+                  <AiOutlineExclamationCircle aria-hidden="true"/>새 비밀번호와 일치하지 않습니다.
                 </AlertMsg>
               </EditWrapper>
             </ContentSet>

--- a/front/src/Pages/Pharm/Pharmacy_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacy_Information.tsx
@@ -31,7 +31,7 @@ export default function PharmacyInformation() {
       ) : null}
       <ImgContainer>
         <ReviewImgInput id="pharmImg" type="file" onChange={(e) => onUpload(e)} accept="image/*" />
-        {imageSrc ? <PharmImg src={imageSrc} /> : <PharmImg src="Images/ImgPreparing.png" />}
+        {imageSrc ? <PharmImg src={imageSrc} /> : <PharmImg src="Images/ImgPreparing.png"  alt="image preparing"/>}
         <Label htmlFor="pharmImg">
           <MdOutlineAddAPhoto aria-hidden="true"/>
           우리 약국 사진추가하기

--- a/front/src/Pages/Pharm/Pharmacy_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacy_Information.tsx
@@ -33,7 +33,7 @@ export default function PharmacyInformation() {
         <ReviewImgInput id="pharmImg" type="file" onChange={(e) => onUpload(e)} accept="image/*" />
         {imageSrc ? <PharmImg src={imageSrc} /> : <PharmImg src="Images/ImgPreparing.png" />}
         <Label htmlFor="pharmImg">
-          <MdOutlineAddAPhoto />
+          <MdOutlineAddAPhoto aria-hidden="true"/>
           우리 약국 사진추가하기
         </Label>
       </ImgContainer>
@@ -54,12 +54,12 @@ export default function PharmacyInformation() {
           <Key>영업시간</Key>
           <Value>
             {isDropDownDown ? (
-              <IoIosArrowDropdown
+              <IoIosArrowDropdown aria-hidden="true"
                 id={`dropDown ${isDropDownDown ? "close" : "open"}`}
                 onClick={() => setIsDropDownDown(!isDropDownDown)}
               />
             ) : (
-              <IoIosArrowDropright
+              <IoIosArrowDropright aria-hidden="true"
                 id={`dropDown ${isDropDownDown ? "close" : "open"}`}
                 onClick={() => setIsDropDownDown(!isDropDownDown)}
               />

--- a/front/src/Pages/Pharm/Pharmacy_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacy_Information.tsx
@@ -27,7 +27,7 @@ export default function PharmacyInformation() {
   return (
     <Content>
       {isModalUp ? (
-        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
       ) : null}
       <ImgContainer>
         <ReviewImgInput id="pharmImg" type="file" onChange={(e) => onUpload(e)} accept="image/*" />

--- a/front/src/Pages/SignOut.tsx
+++ b/front/src/Pages/SignOut.tsx
@@ -39,7 +39,7 @@ export default function SignOut() {
             </span>
             <div>
               <p id="alert" className={errMsg ? "show" : ""}>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 체크박스에 동의가 필요합니다
               </p>
               <p>

--- a/front/src/Pages/SignUp.tsx
+++ b/front/src/Pages/SignUp.tsx
@@ -27,11 +27,11 @@ export default function SignUp() {
     </Total>
   );
 }
-const Total = styled.div`
+const Total = styled.main`
   display: flex;
   justify-content: center;
 `;
-const Container = styled.div`
+const Container = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -39,7 +39,7 @@ const Container = styled.div`
   width: 40rem;
 `;
 
-const Title = styled.div`
+const Title = styled.header`
   display: flex;
   justify-content: center;
   padding-top: 6rem;

--- a/front/src/Pages/SignUp.tsx
+++ b/front/src/Pages/SignUp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 import PharmSignForms from "../Components/SignUpForm/PharmSignForms";
 import SignUpFormTab from "../Components/SignUpForm/SignUpFormTab";
@@ -30,23 +30,23 @@ export default function SignUp() {
 const Total = styled.main`
   display: flex;
   justify-content: center;
+  height: 100vh;
+  width: 100%;
+  overflow-y: scroll;
 `;
 const Container = styled.section`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 100%;
-  width: 40rem;
+  width: 35rem;
 `;
-
 const Title = styled.header`
   display: flex;
   justify-content: center;
-  padding-top: 6rem;
+  align-items: center;
+  gap: 10px;
   img {
-    padding-right: 1rem;
     width: 3.5rem;
-    height: 3rem;
   }
   h1 {
     color: var(--blue-600);

--- a/front/src/Pages/User/MyInfo_Information.tsx
+++ b/front/src/Pages/User/MyInfo_Information.tsx
@@ -103,7 +103,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     <Wrapper>
       <ImgContainer>
         <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
-        {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/User.png" />}
+        {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/User.png"  alt="user"/>}
         <Label htmlFor="img">
           <MdOutlineAddAPhoto aria-hidden="true"/>
           사진추가하기

--- a/front/src/Pages/User/MyInfo_Information.tsx
+++ b/front/src/Pages/User/MyInfo_Information.tsx
@@ -105,7 +105,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
         <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
         {imageSrc ? <ReviewImg src={imageSrc} /> : <ReviewImg src="Images/User.png" />}
         <Label htmlFor="img">
-          <MdOutlineAddAPhoto />
+          <MdOutlineAddAPhoto aria-hidden="true"/>
           사진추가하기
         </Label>
       </ImgContainer>
@@ -128,7 +128,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
                 />
               </InputWrapper>
               <AlertMsg className={`${error.nickname ? "error" : ""}`}>
-                <AiOutlineExclamationCircle />
+                <AiOutlineExclamationCircle aria-hidden="true"/>
                 이름에는 공백이 들어갈 수 없습니다.
               </AlertMsg>
             </EditWrapper>
@@ -173,7 +173,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.password ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />
+                  <AiOutlineExclamationCircle aria-hidden="true"/>
                   비밀번호가 일치하지 않습니다.
                 </AlertMsg>
               </EditWrapper>
@@ -191,7 +191,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.newPassword ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />
+                  <AiOutlineExclamationCircle aria-hidden="true"/>
                   문자 숫자 특수문자 조합 8자 이상으로 조합해주세요.
                 </AlertMsg>
               </EditWrapper>
@@ -209,7 +209,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
                   />
                 </InputWrapper>
                 <AlertMsg className={`${error.confirmNewPassword ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />새 비밀번호와 일치하지 않습니다.
+                  <AiOutlineExclamationCircle aria-hidden="true"/>새 비밀번호와 일치하지 않습니다.
                 </AlertMsg>
               </EditWrapper>
             </ContentSet>

--- a/front/src/Pages/User/MyInfo_likes.tsx
+++ b/front/src/Pages/User/MyInfo_likes.tsx
@@ -43,13 +43,13 @@ export default function MyInfoLikes() {
             return (
               <TableBody key={i}>
                 <Text className="single icon">
-                  <IoIosArrowDropright onClick={() => setIsModalUp(!isModalUp)} />
+                  <IoIosArrowDropright onClick={() => setIsModalUp(!isModalUp)} aria-hidden="true"/>
                 </Text>
                 <Text className="pharm">{data.pharm}</Text>
                 <Text className="address">{data.address}</Text>
                 <Text className="number">{data.tel}</Text>
                 <Text className="single icon">
-                  <RiDeleteBin6Line />
+                  <RiDeleteBin6Line aria-hidden="true"/>
                 </Text>
               </TableBody>
             );
@@ -58,7 +58,7 @@ export default function MyInfoLikes() {
       ) : (
         <WhenEmpty>
           <Add to="/">
-            <IoMdAddCircleOutline id="icon" />
+            <IoMdAddCircleOutline id="icon" aria-hidden="true"/>
           </Add>
           <span>
             <p>현재 찜한 약국이 없습니다.</p>

--- a/front/src/Pages/User/MyInfo_likes.tsx
+++ b/front/src/Pages/User/MyInfo_likes.tsx
@@ -28,7 +28,7 @@ export default function MyInfoLikes() {
   return (
     <Content>
       {isModalUp ? (
-        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
       ) : null}
       <TableHead>
         <Text className="single" />

--- a/front/src/Pages/User/MyInfo_reviews.tsx
+++ b/front/src/Pages/User/MyInfo_reviews.tsx
@@ -52,7 +52,7 @@ export default function MyInfoReviews() {
               <Text className="review">{data.review}</Text>
               <Text className="number">{data.writtenAt}</Text>
               <Text className="single icon">
-                <RiDeleteBin6Line />
+                <RiDeleteBin6Line aria-hidden="true"/>
               </Text>
             </TableBody>
           ))}
@@ -60,7 +60,7 @@ export default function MyInfoReviews() {
       ) : (
         <WhenEmpty>
           <Add to="/">
-            <IoMdAddCircleOutline id="icon" />
+            <IoMdAddCircleOutline id="icon" aria-hidden="true"/>
           </Add>
           <span>
             <p>현재 찜한 약국이 없습니다.</p>

--- a/front/src/Pages/User/MyInfo_reviews.tsx
+++ b/front/src/Pages/User/MyInfo_reviews.tsx
@@ -32,7 +32,7 @@ export default function MyInfoReviews() {
   return (
     <Content>
       {isModalUp ? (
-        <PharmDetail isModalUp={isModalUp} setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
+        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} />
       ) : null}
       <TableHead>
         <Text className="single" />

--- a/front/src/Util/z-index.ts
+++ b/front/src/Util/z-index.ts
@@ -11,15 +11,15 @@ export const zIndex_PharmList = {
 };
 export const zIndex_Modal = {
   ModalBackDrop: 20,
-  ModalContainer: 30,
-  CloseBtnContainer: 40,
-  AnyDropDown: 40,
-  WriteReviewContainer: 50
+  ModalContainer: 21,
+  CloseBtnContainer: 22,
+  AnyDropDown: 22,
+  WriteReviewContainer: 23
 };
 export const zIndex_MyPage = {
   DropDown: 10,
 };
 export const zIndex_AdminPage = {
-  ModalBackDrop: 1,
-  ShowImg: 10,
+  ModalBackDrop: 20,
+  ShowImg: 21,
 };

--- a/front/src/Util/z-index.ts
+++ b/front/src/Util/z-index.ts
@@ -6,3 +6,20 @@ export const zIndex_KakaoMap = {
 export const zIndex_MapFilter = {
   CtrlContainer: 10,
 };
+export const zIndex_PharmList = {
+  ListContainer: 10,
+};
+export const zIndex_Modal = {
+  ModalBackDrop: 20,
+  ModalContainer: 30,
+  CloseBtnContainer: 40,
+  AnyDropDown: 40,
+  WriteReviewContainer: 50
+};
+export const zIndex_MyPage = {
+  DropDown: 10,
+};
+export const zIndex_AdminPage = {
+  ModalBackDrop: 1,
+  ShowImg: 10,
+};


### PR DESCRIPTION
## 1. 멘토링 피드백 수정
<img width="521" alt="image" src="https://user-images.githubusercontent.com/115776596/225806175-ea15708f-5c0b-4268-a9c4-6ec46db832e0.png">

- [x] 약국 상세모달 반응형 화면시 스크롤 이슈 해결
- [x] z-index 상수로 변경 (PharmDetail, PharmList, MyPage, AdminPage)

## 2. 팀원 피드백 수정
<img width="363" alt="image" src="https://user-images.githubusercontent.com/115776596/225806338-ca3edb2a-14f7-4779-935a-dbb97b79bc49.png">

- [x] 약국상세페이지 모달 세로길이 확대
- [x] 기본 이미지에 테두리 추가
- [x] 영업시간 드롭다운 추가

## 3. 접근성 보완
- [x] 아이콘에 aria-hidden="true" 추가
- [x] Input 에 label 추가

## 4. Semantic tag 수정
- [x] PharmList 및 관련 컴포넌트
- [x] PharmItem 및 관련 컴포넌트
- [x] PharmDetail 및 관련 컴포넌트
- [x] SignUp 및 관련 컴포넌트

## 5. CSS 수정
<img width="308" alt="image" src="https://user-images.githubusercontent.com/115776596/225806398-a481ff82-8e04-43df-ae0c-d8cdc518bad7.png">

- [x] SignUp 컨테이너 가로길이 축소
- [x] PharmRank CSS 수정 (간격 등)

## 6. PharmList 눌러서 여닫기 기능 추가
- [x] 반응형 구현

https://user-images.githubusercontent.com/115776596/225806743-25ab7d0f-905d-4eb7-97b6-332e0413c530.mov

