### PR TITLE
FE_CRUD_enhancement

### DIFF
--- a/front/src/Api/APIs.ts
+++ b/front/src/Api/APIs.ts
@@ -20,32 +20,26 @@ export const API_SignOut = {
 };
 // 약국 리스트 -> PharmList.json //
 export const API_PharmLists = {
-  DUMMY_API: "http://localhost:3002/response",
   REAL_API: `${API}/store`,
 };
 // 약국 상세모달 -> Pharm.json //
 export const API_PharmItem = {
-  DUMMY_API: "http://localhost:3020/response",
   REAL_API: `${API}/store`,
 };
 // 약국 상세정보 -> Pharm.json //
 export const API_PharmInfo = {
-  DUMMY_API: "http://localhost:3020/response",
   REAL_API: `${API}/store`,
 };
 // 약국 리뷰 -> Review.json //
 export const API_PharmDetail = {
-  DUMMY_API: "http://localhost:3010/response",
   REAL_API: `${API}/store`,
 };
 // 내약국 상세정보 -> Pharm.json //
 export const API_PharmacyInformation = {
-  DUMMY_API: "http://localhost:3020/response",
   REAL_API: `${API}/store`,
 };
 // 약국 리뷰 -> Review.json //
 export const API_ReviewUnit = {
-  DUMMY_API: "http://localhost:3010/response",
   DELETE_REAL_API: `${API}/store`,
   PATCH_REAL_API: `${API}/store`,
   POST_REAL_API: `${API}/store`,
@@ -53,59 +47,47 @@ export const API_ReviewUnit = {
 };
 // 새 리뷰 작성 -> Review.json //
 export const API_WriteReviewForm = {
-  DUMMY_API: "http://localhost:3010/response",
   POST_REAL_API: `${API}/store`,
 };
 // 리뷰의 댓글 수정
 export const API_ReviewOfReview = {
-  DUMMY_API: "",
   REAL_API: `${API}/review`,
 };
 // 비밀번호 찾기 //
 export const API_FindPW = {
-  DUMMY_API: "http://localhost:3050/response",
   REAL_API: `${API}/users/password`,
 };
 // 일반계정 마이페이지 (myinfo) -> user_myInfo.json //
 export const API_MyInfoInformation = {
-  DUMMY_API: "http://localhost:3030/response",
   REAL_API: `${API}/users`,
 };
 // 일반계정 마이페이지 (myReviews) -> user_myReviews.json//
 export const API_MyInfoReviews = {
-  DUMMY_API: "http://localhost:3040/response",
   REAL_API: `${API}/store`,
 };
 // 일반계정 마이페이지 (MyReview) //! 내가 작성한 리뷰 리스트들 중 한줄
 export const API_MyReview = {
-  DUMMY_API: "http://localhost:3040/response",
   REAL_API: `${API}/store`,
 };
 // 일반계정 마이페이지 (myLikes) -> user_myLikes.json //
 export const API_MyInfoLikes = {
-  DUMMY_API: "http://localhost:3050/response",
   REAL_API: `${API}/users`,
 };
 // 일반계정 마이페이지 (LikedPharmacyUnit) //! 내가 찜한 약국 리스트들 중 한줄
 export const API_LikedPharmacyUnit = {
-  GET_DUMMY_API: "http://localhost:3060/response",
-  GET_REAL_API: `${API}/store`,
-  DELETE_DUMMY_API_: "http://localhost:3060/response",
+  GET_REAL_API: `${API}/store/user`,
   DELETE_REAL_API: `${API}/store`,
 };
 // 약사계정 마이페이지 (Myinfo) -> pharm_myInfo.json //
 export const API_MyPharmInfo = {
-  DUMMY_API: "http://localhost:3060/response",
   REAL_API: `${API}/store`,
 };
 // 약사계정 마이페이지 (MyPharmacy) -> Pharm.json//
 export const API_MyPharmacy = {
-  DUMMY_API: "http://localhost:3020/response",
   REAL_API: `${API}/store`,
 };
 // 관리자계정 전체회원관리 (Users) -> admin_users.json
 export const API_Users = {
-  DUMMY_API: "http://localhost:3080/response",
   GET_REAL_API: `${API}/users`,
   POST_REAL_API: `${API}/admin`,
 };

--- a/front/src/Api/APIs.ts
+++ b/front/src/Api/APIs.ts
@@ -46,12 +46,15 @@ export const API_PharmacyInformation = {
 // 약국 리뷰 -> Review.json //
 export const API_ReviewUnit = {
   DUMMY_API: "http://localhost:3010/response",
-  REAL_API: `${API}/store`,
+  DELETE_REAL_API: `${API}/store`,
+  PATCH_REAL_API: `${API}/store`,
+  POST_REAL_API: `${API}/store`,
+  POST_COMMENT_REAL_API: `${API}`,
 };
 // 새 리뷰 작성 -> Review.json //
 export const API_WriteReviewForm = {
   DUMMY_API: "http://localhost:3010/response",
-  REAL_API: `${API}/store`,
+  POST_REAL_API: `${API}/store`,
 };
 // 리뷰의 댓글 수정
 export const API_ReviewOfReview = {
@@ -108,8 +111,7 @@ export const API_Users = {
 };
 // 관리자계정 약사인증관리 (Certify) -> admin_certify.json
 export const API_Certify = {
-  // GET_REAL_API: `${API}/admin`,
-  GET_REAL_API: "http://ec2-54-180-29-60.ap-northeast-2.compute.amazonaws.com:8080/api/admin",
+  GET_REAL_API: `${API}/admin`,
   POST_SUCCESS_REAL_API: `${API}/admin/access/success`,
   POST_DENIED_REAL_API: `${API}/admin/access/failure`,
 };

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -31,46 +31,6 @@ export default function PharmDetail({
 }: Props) {
 
   const [isReviewFormShown, setIsReviewFormShown] = useState(false);
-  // const [pharmDetail, setPharmDetail] = useState({});
-  // const [reviewList, setReviewList] = useState([]);
-
-  //! GET : 약국상세정보 + 리뷰리스트
-  // useEffect(() => {
-  //   const pharmDetailsAndreviewList = async () => {
-  //     await axios
-  //       .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
-  //       .then((response) => {
-  //         setPharmDetail(response.data.response);
-  //         axios
-  //           .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
-  //           .then((response) => {
-  //             setReviewList(response.data.response.storeReviews);
-  //           })
-  //           .catch((err) => console.log("리뷰받아오던 중" + err));
-  //       })
-  //       .catch((err) => console.log("약국상세받아오던 중" + err));
-  //   };
-  //   pharmDetailsAndreviewList();
-  // }, []);
-
-  // const onModalUp = () => {
-  //   const pharmDetailsAndreviewList = async () => {
-  //     await axios
-  //       .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
-  //       .then((response) => {
-  //         setPharmDetail(response.data.response);
-  //         axios
-  //           .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
-  //           .then((response) => {
-  //             setReviewList(response.data.response.storeReviews);
-  //           })
-  //           .catch((err) => console.log("리뷰받아오던 중" + err));
-  //       })
-  //       .catch((err) => console.log("약국상세받아오던 중" + err));
-  //   };
-  //   pharmDetailsAndreviewList();
-  //   setIsModalUp(false);
-  // };
 
   return (
     <ModalBackDrop onClick={() => setIsModalUp(false)}>

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -1,13 +1,10 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
+import React, { useState } from "react";
 import styled from "styled-components";
 import WriteReviewForm from "./WriteReviewForm";
 import PharmInfo from "./PharmInfo";
 import PharmRank from "../Ul/PharmRank";
 import Button from "../Ul/Button";
 import ReviewList from "./Reviews";
-import { API_PharmItem } from "../../Api/APIs"; // PharmDetail.json
-import { API_PharmDetail } from "../../Api/APIs";
 import { zIndex_Modal } from "../../Util/z-index";
 import { HiXMark } from "react-icons/hi2";
 
@@ -16,32 +13,64 @@ interface Props {
   like?: boolean;
   setLike?: React.Dispatch<React.SetStateAction<boolean>>;
   storeIdx: number;
-  Pharm: any;
+  Pharm?: any;
+  pharmDetail: any;
+  reviewList: any;
+  setReviewList: any;
 }
 
-export default function PharmDetail({ setIsModalUp, like, setLike, storeIdx, Pharm }: Props) {
+export default function PharmDetail({
+  setIsModalUp,
+  like,
+  setLike,
+  storeIdx,
+  Pharm,
+  pharmDetail,
+  reviewList,
+  setReviewList,
+}: Props) {
+
   const [isReviewFormShown, setIsReviewFormShown] = useState(false);
-  const [pharmDetail, setPharmDetail] = useState({});
-  const [reviewList, setReviewList] = useState([]);
+  // const [pharmDetail, setPharmDetail] = useState({});
+  // const [reviewList, setReviewList] = useState([]);
 
   //! GET : 약국상세정보 + 리뷰리스트
-  useEffect(() => {
-    const pharmDetailsAndreviewList = async () => {
-      await axios
-        .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
-        .then((response) => {
-          setPharmDetail(response.data.response);
-          axios
-            .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
-            .then((response) => {
-              setReviewList(response.data.response.storeReviews);
-            })
-            .catch((err) => console.log("리뷰받아오던 중" + err));
-        })
-        .catch((err) => console.log("약국상세받아오던 중" + err));
-    };
-    pharmDetailsAndreviewList();
-  }, []);
+  // useEffect(() => {
+  //   const pharmDetailsAndreviewList = async () => {
+  //     await axios
+  //       .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
+  //       .then((response) => {
+  //         setPharmDetail(response.data.response);
+  //         axios
+  //           .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
+  //           .then((response) => {
+  //             setReviewList(response.data.response.storeReviews);
+  //           })
+  //           .catch((err) => console.log("리뷰받아오던 중" + err));
+  //       })
+  //       .catch((err) => console.log("약국상세받아오던 중" + err));
+  //   };
+  //   pharmDetailsAndreviewList();
+  // }, []);
+
+  // const onModalUp = () => {
+  //   const pharmDetailsAndreviewList = async () => {
+  //     await axios
+  //       .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
+  //       .then((response) => {
+  //         setPharmDetail(response.data.response);
+  //         axios
+  //           .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
+  //           .then((response) => {
+  //             setReviewList(response.data.response.storeReviews);
+  //           })
+  //           .catch((err) => console.log("리뷰받아오던 중" + err));
+  //       })
+  //       .catch((err) => console.log("약국상세받아오던 중" + err));
+  //   };
+  //   pharmDetailsAndreviewList();
+  //   setIsModalUp(false);
+  // };
 
   return (
     <ModalBackDrop onClick={() => setIsModalUp(false)}>

--- a/front/src/Components/Modal/PharmDetail.tsx
+++ b/front/src/Components/Modal/PharmDetail.tsx
@@ -2,14 +2,14 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import WriteReviewForm from "./WriteReviewForm";
-import ReviewUnit from "./ReviewUnit";
 import PharmInfo from "./PharmInfo";
 import PharmRank from "../Ul/PharmRank";
 import Button from "../Ul/Button";
+import ReviewList from "./Reviews";
+import { API_PharmItem } from "../../Api/APIs"; // PharmDetail.json
 import { API_PharmDetail } from "../../Api/APIs";
 import { zIndex_Modal } from "../../Util/z-index";
 import { HiXMark } from "react-icons/hi2";
-import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 interface Props {
   setIsModalUp: React.Dispatch<React.SetStateAction<boolean>>;
@@ -21,22 +21,27 @@ interface Props {
 
 export default function PharmDetail({ setIsModalUp, like, setLike, storeIdx, Pharm }: Props) {
   const [isReviewFormShown, setIsReviewFormShown] = useState(false);
+  const [pharmDetail, setPharmDetail] = useState({});
   const [reviewList, setReviewList] = useState([]);
 
-  //! GET : 리뷰리스트
+  //! GET : 약국상세정보 + 리뷰리스트
   useEffect(() => {
-    const getReviews = async () => {
-      try {
-        const response = await axios.get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`);
-        setReviewList(response.data.response.storeReviews);
-      } catch (error) {
-        console.log(error);
-      }
+    const pharmDetailsAndreviewList = async () => {
+      await axios
+        .get(`${API_PharmItem.REAL_API}/${storeIdx}`)
+        .then((response) => {
+          setPharmDetail(response.data.response);
+          axios
+            .get(`${API_PharmDetail.REAL_API}/${storeIdx}/review`)
+            .then((response) => {
+              setReviewList(response.data.response.storeReviews);
+            })
+            .catch((err) => console.log("리뷰받아오던 중" + err));
+        })
+        .catch((err) => console.log("약국상세받아오던 중" + err));
     };
-    getReviews();
+    pharmDetailsAndreviewList();
   }, []);
-
-  console.log(reviewList)
 
   return (
     <ModalBackDrop onClick={() => setIsModalUp(false)}>
@@ -49,35 +54,24 @@ export default function PharmDetail({ setIsModalUp, like, setLike, storeIdx, Pha
           <PharmRank rating={Pharm.rating} likes={Pharm.pickedStoreCount} reviewCount={Pharm.reviewCount} />
         </InfoHeader>
         <Constant>
-          <PharmInfo like={like} setLike={setLike} Pharm={Pharm} />
-          <ReviewContainer>
-            <ReviewTitle>리뷰</ReviewTitle>
-            {reviewList.length ? (
-              <Reviews>
-                {reviewList.map((review: any) => (
-                  <ReviewUnit
-                    review={review}
-                    key={review.reviewIdx}
-                    reviewIdx={review.reviewIdx}
-                    storeIdx={Pharm.storeIdx}
-                    setReviewList={setReviewList}
-                    reviewList={reviewList}
-                  />
-                ))}
-              </Reviews>
-            ) : (
-              <Instead>
-                <AiOutlineExclamationCircle className="bigger" onClick={() => setIsReviewFormShown(true)} />
-                <p>작성된 리뷰가 없습니다.</p>
-                <p>지금 리뷰를 작성해 보세요!</p>
-              </Instead>
-            )}
-          </ReviewContainer>
+          <PharmInfo like={like} setLike={setLike} Pharm={pharmDetail} />
+          <ReviewList
+            reviewList={reviewList}
+            setReviewList={setReviewList}
+            setIsReviewFormShown={setIsReviewFormShown}
+            storeIdx={storeIdx}
+            Pharm={Pharm}
+          />
         </Constant>
         {isReviewFormShown ? (
-          <WriteReviewForm setIsReviewFormShown={setIsReviewFormShown} storeIdx={Pharm.storeIdx} reviewList={reviewList} setReviewList={setReviewList}/>
+          <WriteReviewForm
+            setIsReviewFormShown={setIsReviewFormShown}
+            storeIdx={Pharm.storeIdx}
+            reviewList={reviewList}
+            setReviewList={setReviewList}
+          />
         ) : null}
-        {/* 로그인이 안된 상태일 경우, 이 부분이 없어야 합니다 */}
+        {/* 로그인이 안된 상태일 경우, 버튼을 누르면 로그인 페이지로 랜딩 */}
         {isReviewFormShown ? null : (
           <WriteReviewBtnContainer>
             <Button onClick={() => setIsReviewFormShown(true)} color="mint" size="md" text="리뷰쓰기" />
@@ -171,53 +165,6 @@ const InfoTitle = styled.h1`
     margin-top: 30px;
   }
 `;
-const ReviewContainer = styled.section`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  height: 510px;
-  width: 450px;
-  padding: 10px 0px 0px 20px;
-  @media (max-width: 768px) {
-    position: static;
-    display: flex;
-    align-items: center;
-    height: auto;
-    padding: 20px 10px 10px 10px;
-    border-bottom: 1px solid var(--black-100);
-  }
-`;
-const ReviewTitle = styled.h2`
-  padding: 10px;
-  font-size: 25px;
-  font-weight: bold;
-  color: var(--black-500);
-  border-bottom: 1px solid var(--black-100);
-  @media (max-width: 768px) {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding-left: 10px;
-    gap: 100px;
-    width: 450px;
-  }
-`;
-const Reviews = styled.section`
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow-y: scroll;
-  padding: 10px 10px 0 0;
-  :active::-webkit-scrollbar-track {
-    width: 0.6rem;
-    visibility: visible;
-  }
-  @media (max-width: 768px) {
-    flex-grow: 0;
-    overflow: visible;
-  }
-`;
 const CloseBtnContainer = styled.div`
   cursor: pointer;
   position: absolute;
@@ -229,27 +176,4 @@ const CloseBtnContainer = styled.div`
   font-size: 40px;
   color: var(--black-100);
   z-index: ${zIndex_Modal.CloseBtnContainer};
-`;
-const Instead = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 20px 0;
-  width: 420px;
-  height: 500px;
-  font-weight: 700;
-  color: var(--black-300);
-  border-radius: 5px;
-  background-color: var(--black-050);
-  .bigger {
-    font-size: 40px;
-    margin-bottom: 10px;
-    :hover {
-      color: var(--black-500);
-    }
-  }
-  @media (max-width: 768px) {
-    height: 200px;
-  }
 `;

--- a/front/src/Components/Modal/PharmInfo.tsx
+++ b/front/src/Components/Modal/PharmInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import PharmRank from "../Ul/PharmRank";
@@ -14,10 +14,17 @@ interface Props {
 export default function PharmInfo({ like, setLike, Pharm }: Props) {
   const [isDropDownDown, setIsDropDownDown] = useState(false);
 
-  //! POST : 찜하기, 찜취소
-  const LikePharmacy = (storeIdx: number) => {
-    //TODO 실제 url 일때 -> /api/store/{storeIdx}/pick
-    axios.delete(`${API_PharmInfo.REAL_API}/${storeIdx}/pick`);
+  //! POST : 찜하기/찜취소
+  const likeThisPharmacy = async () => {
+    try {
+      await axios({
+        url: `${API_PharmInfo.REAL_API}/${Pharm.storeIdx}/pick?userIdx=${1}`, //? 리덕스 툴킷에서 유저인덱스 받아와야 함
+        method: "post",
+      });
+    } catch (error) {
+      console.log(error);
+    }
+    setLike(!like);
   };
 
   return (
@@ -32,12 +39,13 @@ export default function PharmInfo({ like, setLike, Pharm }: Props) {
         ) : (
           <PharmImg src="Images/ImgPreparing.png" alt="이미지 준비중입니다." />
         )}
+        {/* like 의 상태가 아니라 약국 정보에 내가 이 약국을 찜했는지 여부의 boolean 으로 바꿔야 함 */}
         {like ? (
-          <LikeButton onClick={() => LikePharmacy(Pharm.storeIdx)}>
+          <LikeButton onClick={() => likeThisPharmacy()}>
             <img src="./Images/Heart.png" alt="좋아요 상태의 꽉찬 하트입니다." />
           </LikeButton>
         ) : (
-          <LikeButton onClick={() => LikePharmacy(Pharm.storeIdx)}>
+          <LikeButton onClick={() => likeThisPharmacy()}>
             <img src="./Images/UnHeart.png" alt="좋아요 전 상태의 빈 하트입니다." />
           </LikeButton>
         )}

--- a/front/src/Components/Modal/ReviewOfReview.tsx
+++ b/front/src/Components/Modal/ReviewOfReview.tsx
@@ -9,21 +9,18 @@ import { BsArrowReturnRight } from "react-icons/bs";
 import { HiXMark } from "react-icons/hi2";
 
 interface Props {
-  reply: any;
   reviewIdx: number;
-  userIdx: number;
-  replyIdx: number;
+  reply: any;
+  review: any;
+  storeIdx: any;
 }
-export default function ReviewOfReview({ reviewIdx, reply, userIdx, replyIdx }: Props) {
+export default function ReviewOfReview({ reviewIdx, review, reply, storeIdx }: Props) {
   const [isPatchFormShown, setIsPatchFormShown] = useState(false);
-  const [content, setContent] = useState(reply.content);
+  const [content, setContent] = useState(review.content);
 
-  const reviewList = useAppSelector((state: any) => {
-    return state.getReview.response.storeReview;
-  });
-  //  const comment = reviewList.comments.filter((ele:any)=>(
-  //   ele.commentIdx
-  //  ))
+  // const reviewList = useAppSelector((state: any) => {
+  //   return state.getReview.response.storeReview;
+  // });
 
   const handlerReviewOfReview = (e: React.ChangeEvent<HTMLInputElement>) => {
     setContent(e.target.value);
@@ -31,31 +28,25 @@ export default function ReviewOfReview({ reviewIdx, reply, userIdx, replyIdx }: 
 
   //! PATCH : 리뷰의 댓글수정
   const editCommentKeyPress = (e: any) => {
-    e.preventDefault();
-    if (e.key === "Enter") {
+    if (e.key === " " && e.getModifierState("Shift") === false) {
+      e.stopPropagation();
+    } else if (e.key === " " && e.target.value.slice(-1) === " ") {
+      e.stopPropagation();
+    } else if (e.key === "Enter") {
       const formData = new FormData(e.target);
       const reviewOfReview = formData.get("reviewOfReview");
-
-      //* dummy url 일때
       //TODO url 받았을때
       const Data = {
         //? 리덕스 툴킷에서 현재 로그인한 유저의 userIdx 받아와야 함
-        replyIdx,
-        userIdx,
+        storeIdx,
+        userIdx: 1,
         content: reviewOfReview,
       };
-
       const submitReviewOfReview = async () => {
         try {
-          //* dummy url 일때 -> Review.json
-          // await axios({
-          //   url: API_ReviewOfReview.DUMMY_API,
-          //   method: "patch",
-          //   data: Data,
-          // });
-          //TODO url 받았을때 -> /api/store/{storeIdx}/review/{reviewIdx}
+          //TODO url 받았을때 -> /api/review/{reviewIdx}/reply/{replyIdx}
           await axios({
-            url: `${API_ReviewOfReview.REAL_API}/${reviewIdx}/reply/${reply.replyIdx}`,
+            url: `${API_ReviewOfReview.REAL_API}/${reviewIdx}/reply/${review.replyIdx}`,
             method: "patch",
             data: Data,
           });
@@ -63,7 +54,6 @@ export default function ReviewOfReview({ reviewIdx, reply, userIdx, replyIdx }: 
           console.log(error);
         }
       };
-
       submitReviewOfReview();
     }
   };
@@ -76,7 +66,7 @@ export default function ReviewOfReview({ reviewIdx, reply, userIdx, replyIdx }: 
             <BsArrowReturnRight aria-hidden="true" />
           </span>
           <UserIcon src={reply.userImage} alt="pharmacist" />
-          <UserName>{reply.name}</UserName>
+          <UserName>{reply.userName}</UserName>
           <Created>{new Date(reply.createdAt).toLocaleDateString()}</Created>
         </UserInfo>
         <ButtonContainer>

--- a/front/src/Components/Modal/ReviewUnit.tsx
+++ b/front/src/Components/Modal/ReviewUnit.tsx
@@ -61,10 +61,10 @@ export default function ReviewUnit({ review, reviewIdx, storeIdx, reviewList, se
       submitReview();
     }
   };
+
   // ! DELETE : 리뷰삭제
   const deleteReview = async () => {
     try {
-      //TODO url 받았을때 -> //TODO /api/store/{storeIdx}/review/{reviewIdx}
       await axios({
         url: `${API_ReviewUnit.DELETE_REAL_API}/${storeIdx}/review/${reviewIdx}`,
         method: "delete",
@@ -78,7 +78,6 @@ export default function ReviewUnit({ review, reviewIdx, storeIdx, reviewList, se
   //! POST : 리뷰신고
   const reportReview = async () => {
     try {
-      //TODO url 받았을때 -> /api/store/{storeIdx}/review/{reviewIdx}/report
       await axios({
         url: `${API_ReviewUnit.POST_REAL_API}/${storeIdx}/review/${reviewIdx}/report`,
         method: "post",
@@ -93,23 +92,21 @@ export default function ReviewUnit({ review, reviewIdx, storeIdx, reviewList, se
   };
 
   const newComment = {
-    //? 리덕스 툴킷에서 현재 로그인한 유저의 userIdx 받아와야 함
     storeIdx,
     userIdx: 1,
     content: commentContent,
   };
+
   //! POST : 리뷰의 댓글작성
   const submitCommentKeyPress = (e: any) => {
     if (e.key === " " && e.getModifierState("Shift") === false) {
       e.stopPropagation();
     } else if (e.key === " " && e.target.value.slice(-1) === " ") {
       e.stopPropagation();
-    }
-    else if (e.key === "Enter") {
+    } else if (e.key === "Enter") {
       e.preventDefault();
       const reply = async () => {
         try {
-          //TODO url 받았을때 -> /api/review/{reviewIdx}/reply
           await axios({
             url: `${API_ReviewUnit.POST_COMMENT_REAL_API}/review/${reviewIdx}/reply`,
             method: "post",
@@ -132,14 +129,14 @@ export default function ReviewUnit({ review, reviewIdx, storeIdx, reviewList, se
       setReviewList(
         [...reviewList].map(
           (
-            review, // username 임의로 작성해둠, 나중에 리덕스 툴킷에서 가져오기
+            rev, //? username 임의로 작성해둠, 나중에 리덕스 툴킷에서 가져오기
           ) =>
-            review.reviewIdx === reviewIdx
+            rev.reviewIdx === reviewIdx
               ? {
-                  ...review,
-                  replies: [show, ...review.replies],
+                  ...rev,
+                  replies: [show, ...rev.replies],
                 }
-              : review,
+              : rev,
         ),
       );
       reply();
@@ -211,7 +208,15 @@ export default function ReviewUnit({ review, reviewIdx, storeIdx, reviewList, se
         </WriteCommentForm>
       ) : null}
       {review.replies?.map((reply: any) => (
-        <ReviewOfReview key={reply.replyIdx} reviewIdx={reviewIdx} reply={reply} review={review} storeIdx={storeIdx}/>
+        <ReviewOfReview
+          key={reply.replyIdx}
+          reviewIdx={reviewIdx}
+          reply={reply}
+          review={review}
+          storeIdx={storeIdx}
+          reviewList={reviewList}
+          setReviewList={setReviewList}
+        />
       ))}
     </ReviewUnitContainer>
   );

--- a/front/src/Components/Modal/Reviews.tsx
+++ b/front/src/Components/Modal/Reviews.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import styled from "styled-components";
+import ReviewUnit from "./ReviewUnit";
+import { API_PharmDetail } from "../../Api/APIs";
+import { zIndex_Modal } from "../../Util/z-index";
+import { AiOutlineExclamationCircle } from "react-icons/ai";
+
+interface Props {
+  reviewList: any;
+  setReviewList: any;
+  setIsReviewFormShown: any;
+  storeIdx: number;
+  Pharm: any;
+}
+
+export default function ReviewList({ reviewList, setReviewList, setIsReviewFormShown, storeIdx, Pharm }: Props) {
+
+  console.log(reviewList)
+  return (
+    <ReviewContainer>
+      <ReviewTitle>리뷰</ReviewTitle>
+      {reviewList.length ? (
+        <Reviews>
+          {reviewList.map((review: any) => (
+            <ReviewUnit
+              review={review}
+              key={review.reviewIdx}
+              reviewIdx={review.reviewIdx}
+              storeIdx={Pharm.storeIdx}
+              setReviewList={setReviewList}
+              reviewList={reviewList}
+            />
+          ))}
+        </Reviews>
+      ) : (
+        <Instead>
+          <AiOutlineExclamationCircle className="bigger" onClick={() => setIsReviewFormShown(true)} />
+          <p>작성된 리뷰가 없습니다.</p>
+          <p>지금 리뷰를 작성해 보세요!</p>
+        </Instead>
+      )}
+    </ReviewContainer>
+  );
+}
+
+const ReviewContainer = styled.section`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 510px;
+  width: 450px;
+  padding: 10px 0px 0px 20px;
+  @media (max-width: 768px) {
+    position: static;
+    display: flex;
+    align-items: center;
+    height: auto;
+    padding: 20px 10px 10px 10px;
+    border-bottom: 1px solid var(--black-100);
+  }
+`;
+const ReviewTitle = styled.h2`
+  padding: 10px;
+  font-size: 25px;
+  font-weight: bold;
+  color: var(--black-500);
+  border-bottom: 1px solid var(--black-100);
+  @media (max-width: 768px) {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-left: 10px;
+    gap: 100px;
+    width: 450px;
+  }
+`;
+const Reviews = styled.section`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  overflow-y: scroll;
+  padding: 10px 10px 0 0;
+  :active::-webkit-scrollbar-track {
+    width: 0.6rem;
+    visibility: visible;
+  }
+  @media (max-width: 768px) {
+    flex-grow: 0;
+    overflow: visible;
+  }
+`;
+const Instead = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 20px 0;
+  width: 420px;
+  height: 500px;
+  font-weight: 700;
+  color: var(--black-300);
+  border-radius: 5px;
+  background-color: var(--black-050);
+  .bigger {
+    font-size: 40px;
+    margin-bottom: 10px;
+    :hover {
+      color: var(--black-500);
+    }
+  }
+  @media (max-width: 768px) {
+    height: 200px;
+  }
+`;

--- a/front/src/Components/Modal/Reviews.tsx
+++ b/front/src/Components/Modal/Reviews.tsx
@@ -1,9 +1,5 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
 import styled from "styled-components";
 import ReviewUnit from "./ReviewUnit";
-import { API_PharmDetail } from "../../Api/APIs";
-import { zIndex_Modal } from "../../Util/z-index";
 import { AiOutlineExclamationCircle } from "react-icons/ai";
 
 interface Props {
@@ -15,8 +11,6 @@ interface Props {
 }
 
 export default function ReviewList({ reviewList, setReviewList, setIsReviewFormShown, storeIdx, Pharm }: Props) {
-
-  console.log(reviewList)
   return (
     <ReviewContainer>
       <ReviewTitle>리뷰</ReviewTitle>
@@ -24,8 +18,8 @@ export default function ReviewList({ reviewList, setReviewList, setIsReviewFormS
         <Reviews>
           {reviewList.map((review: any) => (
             <ReviewUnit
-              review={review}
               key={review.reviewIdx}
+              review={review}
               reviewIdx={review.reviewIdx}
               storeIdx={Pharm.storeIdx}
               setReviewList={setReviewList}

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -8,7 +8,6 @@ import { BiPhotoAlbum } from "react-icons/bi";
 import { HiXMark } from "react-icons/hi2";
 import { zIndex_Modal } from "../../Util/z-index";
 import { API_WriteReviewForm } from "../../Api/APIs"; // Review.json
-import { useAppSelector, useAppDispatch } from "../../Redux/hooks";
 
 interface Props {
   setIsReviewFormShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -71,7 +70,6 @@ export default function WriteReviewForm({ setIsReviewFormShown, storeIdx, review
     formDataForsubmit.append("image", imgFile);
 
     //! POST : 리뷰작성
-    //TODO /api/store/{storeIdx}/review
     const postReview = async () => {
       try {
         await axios({

--- a/front/src/Components/Modal/WriteReviewForm.tsx
+++ b/front/src/Components/Modal/WriteReviewForm.tsx
@@ -61,7 +61,7 @@ export default function WriteReviewForm({ setIsReviewFormShown, storeIdx, review
     const star = formData.get("rating");
 
     let data: any = {
-      userIdx: 1,
+      userIdx: 3,
       content: review.content,
       rating: review.rating,
     };
@@ -71,10 +71,11 @@ export default function WriteReviewForm({ setIsReviewFormShown, storeIdx, review
     formDataForsubmit.append("image", imgFile);
 
     //! POST : 리뷰작성
+    //TODO /api/store/{storeIdx}/review
     const postReview = async () => {
       try {
         await axios({
-          url: `${API_WriteReviewForm.REAL_API}/${storeIdx}/review`,
+          url: `${API_WriteReviewForm.POST_REAL_API}/${storeIdx}/review`,
           method: "post",
           data: formDataForsubmit,
         });
@@ -87,7 +88,7 @@ export default function WriteReviewForm({ setIsReviewFormShown, storeIdx, review
     let show: any = {
       userIdx: 1, //? 리덕스 툴킷에서 userIdx 가져오기
       userImage: review.userImage,
-      userName: "회원", //? 리덕스 툴킷에서 name 가져오기
+      userName: "나 회원 아니거든?", //? 리덕스 툴킷에서 name 가져오기
       content: review.content,
       rating: review.rating,
       reviewImage: imageSrc,

--- a/front/src/Components/PharmList/PharmItem.tsx
+++ b/front/src/Components/PharmList/PharmItem.tsx
@@ -12,20 +12,7 @@ interface Props {
 
 export default function PharmItem({ Pharm, storeIdx }: Props) {
   const [isModalUp, setIsModalUp] = useState(false);
-  const [pharmDetail, setPharmDetail] = useState();
   const [like, setLike] = useState(false);
-
-  useEffect(() => {
-    const getPharmDetail = async () => {
-      try {
-        const response = await axios.get(`${API_PharmItem.REAL_API}/${storeIdx}`);
-        setPharmDetail(response.data.response);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    getPharmDetail();
-  }, []);
 
   return (
     <PharmCard>
@@ -34,7 +21,7 @@ export default function PharmItem({ Pharm, storeIdx }: Props) {
           setIsModalUp={setIsModalUp}
           like={like}
           setLike={setLike}
-          Pharm={pharmDetail}
+          Pharm={Pharm}
           storeIdx={Pharm.storeIdx}
         />
       ) : null}

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -1,5 +1,5 @@
 //홈화면 옆에 약국 리스트
-import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import PharmItem from "./PharmItem";
 import SearchBar from "./SearchBar";
@@ -12,10 +12,9 @@ interface Props {
   hidden: SELECT_HIDDEN;
   setHidden: Dispatch<SetStateAction<SELECT_HIDDEN>>;
   totalPharmList: object[];
-  setTotalPharmList: any;
 }
 
-export default function PharmLists({ hidden, setHidden, totalPharmList, setTotalPharmList }: Props) {
+export default function PharmLists({ hidden, setHidden, totalPharmList }: Props) {
 
   return (
     <ContainerList className={hidden ? "hide" : ""}>

--- a/front/src/Components/PharmList/PharmLists.tsx
+++ b/front/src/Components/PharmList/PharmLists.tsx
@@ -1,5 +1,5 @@
 //홈화면 옆에 약국 리스트
-import React, { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction } from "react";
 import styled from "styled-components";
 import PharmItem from "./PharmItem";
 import SearchBar from "./SearchBar";
@@ -53,7 +53,7 @@ export default function PharmLists({ hidden, setHidden, totalPharmList }: Props)
           </ListHead>
           <ListBody>
             {totalPharmList?.map((pharm: any) => (
-              <PharmItem Pharm={pharm} key={pharm.storeIdx} storeIdx={pharm.storeIdx} />
+              <PharmItem key={pharm.storeIdx} Pharm={pharm} storeIdx={pharm.storeIdx} />
             ))}
           </ListBody>
         </PharmList>

--- a/front/src/Components/SignUpForm/ErrorAlert.tsx
+++ b/front/src/Components/SignUpForm/ErrorAlert.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import styled from "styled-components";
 import { AiOutlineExclamationCircle } from "react-icons/ai";
 

--- a/front/src/Components/SignUpForm/SignUpInput.tsx
+++ b/front/src/Components/SignUpForm/SignUpInput.tsx
@@ -10,7 +10,6 @@ interface Props {
   readOnly?: boolean;
   className?: string;
 }
-//? signUpInput으로 하면 에러남=> TS는 가장 처음 레터를 대문자로 해야?
 
 export default function SignUpInput({ type, name, placeholder, value, onChange, readOnly, className }: Props) {
   return (

--- a/front/src/Components/SignUpForm/UserSignUpForms.tsx
+++ b/front/src/Components/SignUpForm/UserSignUpForms.tsx
@@ -122,7 +122,6 @@ export default function UserSignUpForms() {
     //! POST : 일반회원 회원가입 - JWT
     const postSignUp = async () => {
       try {
-        //TODO api/users/normal
         await axios({
           url: API_UserSignUpForms.REAL_API,
           method: "post",

--- a/front/src/Components/Ul/PharmRank.tsx
+++ b/front/src/Components/Ul/PharmRank.tsx
@@ -12,7 +12,7 @@ export default function PharmRank({ rating, likes, reviewCount }: Props) {
     <Container>
       <div>{rating ? <BsStarFill className="select_star" /> : <BsStar className="unSelect_star" />}</div>
       <Star>
-        {Number.isInteger(rating) ? rating :rating.toFixed(1)}
+        {rating ? rating.toFixed(1) : rating}
         <span className="rest">/5</span>
       </Star>
       <Selected>찜콩 {likes}</Selected>
@@ -58,12 +58,10 @@ const Star = styled.span`
 `;
 
 const Selected = styled.span`
-
   font-size: 0.9rem;
   color: var(--black-400);
 `;
 const TotalReview = styled.span`
-
   font-size: 0.9rem;
   color: var(--black-400);
 `;

--- a/front/src/Pages/Admin/AdminTabs.tsx
+++ b/front/src/Pages/Admin/AdminTabs.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 

--- a/front/src/Pages/Admin/Cert.tsx
+++ b/front/src/Pages/Admin/Cert.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 import ImageUp from "./ImageUp";
 

--- a/front/src/Pages/Admin/Certify.tsx
+++ b/front/src/Pages/Admin/Certify.tsx
@@ -60,7 +60,7 @@ export default function Certify() {
       await axios({
         url: API_Certify.POST_DENIED_REAL_API,
         method: "post",
-        data: setCheckedList,
+        data: { userIdxs: checkedList },
       });
     } catch (error) {
       console.log(error);
@@ -204,6 +204,7 @@ const Instead = styled.section`
   align-items: center;
   gap: 20px;
   height: 26rem;
+  width: calc(1150px + 0.6rem);
   color: var(--black-100);
   font-size: 6rem;
   font-weight: bold;

--- a/front/src/Pages/Admin/Certify.tsx
+++ b/front/src/Pages/Admin/Certify.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import AdminTabs from "./AdminTabs";
@@ -16,7 +16,6 @@ export default function Certify() {
   useEffect(() => {
     const getCertificates = async () => {
       try {
-        //TODO 실제 url 일때 -> /api/admin/access/requests
         const response = await axios.get(`${API_Certify.GET_REAL_API}/access/requests`);
         console.log(response);
         setCertificates(response.data);
@@ -42,7 +41,6 @@ export default function Certify() {
   //! POST : 약사인증신청 승인
   const successCertify = async () => {
     try {
-      //TODO /api/admin/access/success
       await axios({
         url: API_Certify.POST_SUCCESS_REAL_API,
         method: "post",
@@ -56,7 +54,6 @@ export default function Certify() {
   //! POST : 약사인증신청 반려
   const deniedCertify = async () => {
     try {
-      //TODO /api/admin/access/failure
       await axios({
         url: API_Certify.POST_DENIED_REAL_API,
         method: "post",

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -17,8 +17,7 @@ export default function Reports() {
       try {
         //TODO /api/admin/reports
         const response = await axios.get(API_Reports.GET_REAL_API);
-        setReports(response.data.response.reportedReview);
-        console.log(reports);
+        setReports(response.data.response.reportedReviews);
       } catch (error) {
         console.log(error);
       }
@@ -30,9 +29,9 @@ export default function Reports() {
   const onCheckedItem = useCallback(
     (checked: boolean, id: string) => {
       if (checked) {
-        setCheckedList((prev) => [...prev, { userIdx: id }]);
+        setCheckedList((prev) => [...prev, { reviewIdx: id }]);
       } else if (!checked) {
-        setCheckedList(checkedList.filter((check) => check.userIdx !== id));
+        setCheckedList(checkedList.filter((check) => check.reviewIdx !== id));
       }
     },
     [checkedList],
@@ -41,12 +40,12 @@ export default function Reports() {
   //! DELETE : 신고누적리뷰 삭제
   const deleteReview = async () => {
     try {
-      //TODO /api/admin/access/success
+      //TODO /api/admin/reports
       await axios({
         url: API_Reports.DELETE_REAL_API,
         method: "delete",
-        data: setCheckedList,
-      });
+        data: { reviews: checkedList },
+      }).then(() => location.reload());
     } catch (error) {
       console.log(error);
     }
@@ -59,7 +58,9 @@ export default function Reports() {
       await axios({
         url: API_Reports.POST_REAL_API,
         method: "post",
-        data: setCheckedList,
+        data: { reviews: checkedList },
+      }).then(() => {
+        location.reload();
       });
     } catch (error) {
       console.log(error);
@@ -94,14 +95,14 @@ export default function Reports() {
                   <Content key={i}>
                     <Values className="checkBox">
                       <CheckBox
-                        id={report.reportIdx}
+                        id={report.reviewIdx}
                         onChange={(e: any) => onCheckedItem(e.target.checked, e.target.id)}
                       />
                     </Values>
-                    <Values className="content">{report.reviewContent}</Values>
+                    <Values className="content">{report.content}</Values>
                     <Values className="email">{report.email}</Values>
-                    <Values className="writtenAt">{new Date(report.reviewCreatedAt).toLocaleDateString()}</Values>
-                    <Values className="reports">{report.reportedCount}</Values>
+                    <Values className="writtenAt">{new Date(report.createdAt).toLocaleDateString()}</Values>
+                    <Values className="reports">{report.reportCnt}</Values>
                   </Content>
                 ))}
               </BelowLable>

--- a/front/src/Pages/Admin/Reports.tsx
+++ b/front/src/Pages/Admin/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import styled from "styled-components";
 import AdminTabs from "./AdminTabs";
@@ -15,7 +15,6 @@ export default function Reports() {
   useEffect(() => {
     const getReports = async () => {
       try {
-        //TODO /api/admin/reports
         const response = await axios.get(API_Reports.GET_REAL_API);
         setReports(response.data.response.reportedReviews);
       } catch (error) {
@@ -40,7 +39,6 @@ export default function Reports() {
   //! DELETE : 신고누적리뷰 삭제
   const deleteReview = async () => {
     try {
-      //TODO /api/admin/reports
       await axios({
         url: API_Reports.DELETE_REAL_API,
         method: "delete",
@@ -54,7 +52,6 @@ export default function Reports() {
   //! POST : 신고누적리뷰 복구
   const restoreReview = async () => {
     try {
-      //TODO /api/admin/access/failure
       await axios({
         url: API_Reports.POST_REAL_API,
         method: "post",

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -36,12 +36,11 @@ export default function Users() {
     },
     [checkedList],
   );
-  // console.log(users);
+  console.log(users);
 
   //! POST : 계정 정지
   const blockUsers = async () => {
     try {
-      //TODO /api/admin/block?period=XX
       const response = await axios({
         url: `${API_Users.POST_REAL_API}/block?period=${time}`,
         method: "post",
@@ -56,7 +55,6 @@ export default function Users() {
   //! POST : 계정 강퇴
   const fireUsers = async () => {
     try {
-      //TODO /api/admin/fired
       await axios({
         url: `${API_Users.POST_REAL_API}/fired`,
         method: "post",

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -12,12 +12,12 @@ export default function Users() {
   const [time, setTime] = useState(0);
   const [checkedList, setCheckedList] = useState<Array<any>>([]);
 
+  //! GET : 신고리뷰 리스트 불러오기
   useEffect(() => {
     const getUsers = async () => {
       try {
         const response = await axios.get(API_Users.GET_REAL_API);
         setUsers(response.data.response.content);
-        console.log(users)
       } catch (error) {
         console.log(error);
       }
@@ -36,22 +36,18 @@ export default function Users() {
     },
     [checkedList],
   );
+  // console.log(users);
 
   //! POST : 계정 정지
   const blockUsers = async () => {
     try {
       //TODO /api/admin/block?period=XX
-      // console.log("time");
-      // console.log(time);
-      // console.log("");
-      // console.log("checkedList");
-      // console.log(checkedList);
-      // console.log("");
-      await axios({
+      const response = await axios({
         url: `${API_Users.POST_REAL_API}/block?period=${time}`,
         method: "post",
-        data: checkedList,
+        data: { userIdxs: checkedList },
       });
+      console.log(response)
     } catch (error) {
       console.log(error);
     }
@@ -64,19 +60,18 @@ export default function Users() {
       await axios({
         url: `${API_Users.POST_REAL_API}/fired`,
         method: "post",
-        data: checkedList,
+        data: { userIdxs: checkedList },
       });
     } catch (error) {
       console.log(error);
     }
   };
-  
+
   //! ???? : 계정 복구
   const restoreUsers = async () => {
     try {
       //TODO --------------
-      await axios({
-      });
+      await axios({});
     } catch (error) {
       console.log(error);
     }
@@ -118,7 +113,7 @@ export default function Users() {
             {users.length ? (
               <BelowLable>
                 {users.map((user: any, i) => (
-                  <Content key={i} className={user.accountStatus === "suspended" ? "suspended" : ""}>
+                  <Content key={i} className={user.userStatus === "ACTIVE" ? "" : "suspended"}>
                     <Values className="checkBox">
                       <CheckBox
                         id={user.userIdx}
@@ -127,8 +122,8 @@ export default function Users() {
                         }}
                       />
                     </Values>
-                    <Values className="classification">{user.classification}</Values>
-                    <Values className="accountStatus">{user.accountStatus}</Values>
+                    <Values className="classification">{user.userType}</Values>
+                    <Values className="accountStatus">{user.userStatus}</Values>
                     <Values className="nickname">{user.name}</Values>
                     <Values className="email">{user.email}</Values>
                     <Values className="returnAt">{user.returnAt}</Values>

--- a/front/src/Pages/Admin/Users.tsx
+++ b/front/src/Pages/Admin/Users.tsx
@@ -12,7 +12,7 @@ export default function Users() {
   const [time, setTime] = useState(0);
   const [checkedList, setCheckedList] = useState<Array<any>>([]);
 
-  //! GET : 신고리뷰 리스트 불러오기
+  //! GET : 전체 회원 리스트 불러오기
   useEffect(() => {
     const getUsers = async () => {
       try {

--- a/front/src/Pages/FindPW.tsx
+++ b/front/src/Pages/FindPW.tsx
@@ -34,7 +34,6 @@ export default function FindPW() {
       return alert("항목을 다시 확인해주세요");
     } else
       await axios({
-        //TODO url 받았을때 -> api/users/password/{userIdx}
         //? userIdx 가 없는데 어떻게 보내지? 지금은 일단 임의로 1
         url: `${API_FindPW.REAL_API}/${1}`,
         method: "patch",
@@ -42,16 +41,6 @@ export default function FindPW() {
           email,
         },
       });
-
-    // else
-    // // * dummy data 일때
-    //   await axios({
-    //     url: API_FindPW.DUMMY_API,
-    //     method: "patch",
-    //     data: {
-    //       email,
-    //     },
-    //   });
   };
 
   return (

--- a/front/src/Pages/Home.tsx
+++ b/front/src/Pages/Home.tsx
@@ -209,6 +209,10 @@ export default function Home() {
       };
       getPharmLists();
 
+      // console.log("totalPharmList");
+      // console.log(totalPharmList);
+      // console.log("");
+
       // const markers = filteredPharmacies.map((pharmacy: { lat: any; lng: any; name: any }) => {
       //   const PositionPharmacy = new kakao.maps.LatLng(pharmacy.lat, pharmacy.lng);
       //   const content = '<div class="customoverlay">' + `<span class="title">${pharmacy.name}</span>` + "</div>";
@@ -289,12 +293,7 @@ export default function Home() {
         setTotalPharmList={setTotalPharmList}
         _map={_map}
       />
-      <PharmLists
-        hidden={hidden}
-        setHidden={setHidden}
-        totalPharmList={totalPharmList}
-        setTotalPharmList={setTotalPharmList}
-      />
+      <PharmLists hidden={hidden} setHidden={setHidden} totalPharmList={totalPharmList} />
     </>
   );
 }

--- a/front/src/Pages/Login.tsx
+++ b/front/src/Pages/Login.tsx
@@ -78,17 +78,10 @@ export default function Login() {
       await axios
         .post(API_UserLogIn.REAL_API, { email: email, password: password })
         .then((res) => {
-          //! accessToken어떤 키로 주는지 보고, 잘들어오는지 확인하기
-          // let accessToken = res.headers.Authorization;
-          // let refreshToken = res.headers.Refresh;
-
+         
           let accessToken = res.headers.authorization;
           let refreshToken = res.headers.refresh;
-
-          console.log("response", res);
-          console.log("access 토큰 :", accessToken);
-          console.log("refresh 토큰 :", refreshToken);
-
+          
           //localStorage에 토큰 넣음
           setLocalStorage("access_token", accessToken);
           setLocalStorage("refresh_token", refreshToken);

--- a/front/src/Pages/Login.tsx
+++ b/front/src/Pages/Login.tsx
@@ -10,7 +10,6 @@ import axios from "axios";
 import { API_UserLogIn } from "../Api/APIs";
 import { setLocalStorage } from "../Api/localStorage";
 
-
 export default function Login() {
   const [loginForm, setLoginForms] = useState({
     email: "",
@@ -86,8 +85,9 @@ export default function Login() {
           let accessToken = res.headers.authorization;
           let refreshToken = res.headers.refresh;
 
-          // console.log("access 토큰 :", accessToken);
-          // console.log("refresh 토큰 :", refreshToken);
+          console.log("response", res);
+          console.log("access 토큰 :", accessToken);
+          console.log("refresh 토큰 :", refreshToken);
 
           //localStorage에 토큰 넣음
           setLocalStorage("access_token", accessToken);
@@ -112,7 +112,7 @@ export default function Login() {
     };
     postLogin();
   };
-  
+
   //! POST : 로그인 - Auth
   const postAuthSignUp = async () => {
     try {
@@ -136,7 +136,7 @@ export default function Login() {
         </Title>
         <ContentContainer>
           <Google>
-            <button className="google_button" onClick={()=>postAuthSignUp()}>
+            <button className="google_button" onClick={() => postAuthSignUp()}>
               <GoogleButton>
                 <img className="google_img" alt="google" src="Images/google.png" />
                 <span className="google">Sign up with Google</span>

--- a/front/src/Pages/Pharm/Pharmacist_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacist_Information.tsx
@@ -1,33 +1,41 @@
-import { useDaumPostcodePopup } from "react-daum-postcode";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import Button from "../../Components/Ul/Button";
-import InputAlert from "../User/InputAlert";
-import SignUpInput from "../../Components/SignUpForm/SignUpInput";
-import { validators } from "../../Components/SignUpForm/Validation";
+import axios from "axios";
 import { MdOutlineAddAPhoto } from "react-icons/md";
-import { AiOutlineExclamationCircle } from "react-icons/ai";
+import { API_MyInfoInformation } from "../../Api/APIs";
 
 interface Props {
   scriptUrl?: string;
 }
 
-let dummy = {
-  myInfo: {
-    joined: "2021.03.29",
-    nickname: "caffeine",
-    password: "caffeine1234!@#$",
-    email: "JudiPark0426@github.com",
-    address: "서울시 종로구 대학로 101",
-  },
-};
-
 export default function PharmacistInformation({ scriptUrl }: Props) {
+  const [myInfo, setMyInfo]: any = useState({
+    createdAt: "",
+    name: "",
+    email: "",
+    address: "",
+  });
+
+  const [imgFile, setImgFlie]: any = useState(null);
+
   //! GET : 유저 정보
+  useEffect(() => {
+    const getReviews = async () => {
+      try {
+        //? userIdx 는 리덕스 툴킷에서 -> 2
+        const response = await axios.get(`${API_MyInfoInformation.REAL_API}/${2}`);
+        setMyInfo(response.data.response);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getReviews();
+  }, []);
 
   const [imageSrc, setImageSrc] = useState<string | ArrayBuffer | null>(null);
   const onUpload = (e: any) => {
     const file = e.target.files[0];
+    setImgFlie(file);
     const reader = new FileReader();
     reader.readAsDataURL(file);
     return new Promise<void>((resolve) => {
@@ -37,282 +45,64 @@ export default function PharmacistInformation({ scriptUrl }: Props) {
       };
     });
   };
-  const [isEditing, setIsEditing] = useState(false);
-  const [signForm, setSignForms] = useState({
-    name: dummy.myInfo.nickname,
-    password: "",
-    newPassword: "",
-    confirmNewPassword: "",
-    address: dummy.myInfo.address,
-  });
-  const [error, setError] = useState({
-    name: false,
-    password: false,
-    newPassword: false,
-    confirmNewPassword: false,
-  });
 
-  const FORM_FIELD_NAMES = {
-    NAME: "name",
-    PASSWORD: "password",
-    NEWPASSWORD: "newPassword",
-    CONFIRMNEWPASSWORD: "confirmNewPassword",
-    ADDRESS: "address",
-  };
-
-  const changeNameHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setSignForms({
-      ...signForm,
-      [name]: value,
-    });
-    let errors;
-    if (name === FORM_FIELD_NAMES.NAME) {
-      errors = validators.validateName(value);
-    }
-    setError({
-      ...error,
-      [name]: errors,
-    });
-  };
-
-  const changeAddressHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setSignForms({
-      ...signForm,
-      [name]: value,
-    });
-  };
-
-  //현재비밀번호
-  const changeNowPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setSignForms({
-      ...signForm,
-      [name]: value,
-    });
-    let errors;
-    if (name === FORM_FIELD_NAMES.PASSWORD) {
-      errors = validators.validatePasswordCheck(dummy.myInfo.password, value);
-    }
-    setError({
-      ...error,
-      [name]: errors,
-    });
-  };
-
-  //새비밀번호
-  const changeNewPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setSignForms({
-      ...signForm,
-      [name]: value,
-    });
-    let errors;
-    if (name === FORM_FIELD_NAMES.NEWPASSWORD) {
-      errors = validators.validatePassword(value);
-    }
-
-    setError({
-      ...error,
-      [name]: errors,
-    });
-  };
-
-  //새비밀번호 체크
-  const changeNewConfirmPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setSignForms({
-      ...signForm,
-      [name]: value,
-    });
-    let errors;
-    if (name === FORM_FIELD_NAMES.CONFIRMNEWPASSWORD) {
-      errors = validators.validatePasswordCheck(signForm.newPassword, value);
-    }
-    setError({
-      ...error,
-      [name]: errors,
-    });
-  };
-
-  const open = useDaumPostcodePopup(scriptUrl);
-
-  const handleComplete = (data: any) => {
-    let fullAddress = data.address;
-    let extraAddress = "";
-
-    if (data.addressType === "R") {
-      if (data.bname !== "") {
-        extraAddress += data.bname;
-      }
-      if (data.buildingName !== "") {
-        extraAddress += extraAddress !== "" ? `, ${data.buildingName}` : data.buildingName;
-      }
-      fullAddress += extraAddress !== "" ? ` (${extraAddress})` : "";
-    }
-
-    setSignForms((prev) => ({ ...prev, address: fullAddress }));
-  };
-
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    open({ onComplete: handleComplete });
+  const submitUserImg = (e: any) => {
     e.preventDefault();
-  };
+    const formDataImgsubmit = new FormData();
+    formDataImgsubmit.append("image", imgFile);
 
-  const onSubmit: any = (e: { preventDefault: () => void; target: HTMLFormElement | undefined }) => {
-    e.preventDefault();
-    const formData = new FormData(e.target);
-    const password = formData.get(FORM_FIELD_NAMES.PASSWORD);
-    const name = formData.get(FORM_FIELD_NAMES.NAME);
-    const address = formData.get(FORM_FIELD_NAMES.ADDRESS);
-    const newPassword = formData.get(FORM_FIELD_NAMES.NEWPASSWORD);
-    const confirmNewPassword = formData.get(FORM_FIELD_NAMES.CONFIRMNEWPASSWORD);
+    // TODO : 리덕스 툴킷에서 userIdx가져와 [JSON.stringify(userIdx)] 수정 => 아래주석 코드 지우면 안돼!
+    //   formDataImgsubmit.append("userIdx", new Blob([JSON.stringify(userIdx)], { type: "application/json" }));
+    //
 
-    if (!password || !name || !address) {
-      return alert("필수값을 입력해주세요");
-    }
-    if (
-      error.password === true ||
-      error.name === true ||
-      error.newPassword === true ||
-      error.confirmNewPassword === true
-    ) {
-      return alert("항목을 다시 확인해주세요");
-    }
-
-    if (newPassword !== confirmNewPassword) {
-      return alert("새 비밀번호를 한번 더 입력해주세요");
-    }
+    const submitNewImg: any = async () => {
+      try {
+        await axios({
+          url: `${API_MyInfoInformation.REAL_API}/image`,
+          method: "patch",
+          data: formDataImgsubmit,
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    submitNewImg();
   };
 
   return (
-    <Wrapper onSubmit={onSubmit}>
+    <Wrapper>
       <ImgContainer>
         <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
         {imageSrc ? <ReviewImg src={imageSrc as string} /> : <ReviewImg src="Images/Pharm.png" />}
-        <Label htmlFor="img">
-          <MdOutlineAddAPhoto aria-hidden="true" />
-          사진추가하기
-        </Label>
+        {imageSrc ? (
+          <Label onClick={submitUserImg}>
+            <MdOutlineAddAPhoto aria-hidden="true" />
+            사진수정완료
+          </Label>
+        ) : (
+          <Label htmlFor="img">
+            <MdOutlineAddAPhoto aria-hidden="true" />
+            사진수정하기
+          </Label>
+        )}
       </ImgContainer>
       <Content>
         <ContentSet>
           <ContentKey>가입일</ContentKey>
-          <ContentValue>{dummy.myInfo.joined}</ContentValue>
+          <ContentValue>{new Date(myInfo.createdAt).toLocaleDateString()}</ContentValue>
         </ContentSet>
         <ContentSet>
           <ContentKey>닉네임</ContentKey>
-          {isEditing ? (
-            <EditWrapper>
-              <InputWrapper className={`${error.name ? "error" : ""}`}>
-                <SignUpInput
-                  type={"text"}
-                  name={FORM_FIELD_NAMES.NAME}
-                  placeholder={"닉네임을 입력하세요."}
-                  value={signForm.name}
-                  onChange={changeNameHandler}
-                />
-              </InputWrapper>
-              <InputAlert value={signForm.name} />
-              <AlertMsg className={`${error.name ? "error" : ""}`}>
-                <AiOutlineExclamationCircle aria-hidden="true" />
-                이름에는 공백이 들어갈 수 없습니다.
-              </AlertMsg>
-            </EditWrapper>
-          ) : (
-            <ContentValue>{dummy.myInfo.nickname}</ContentValue>
-          )}
+          <ContentValue>{myInfo.name}</ContentValue>
         </ContentSet>
         <ContentSet>
           <ContentKey>email</ContentKey>
-          <ContentValue>{dummy.myInfo.email}</ContentValue>
+          <ContentValue>{myInfo.email}</ContentValue>
         </ContentSet>
         <ContentSet>
           <ContentKey>주소</ContentKey>
-          {isEditing ? (
-            <InputWrapper>
-              <SignUpInput
-                readOnly
-                type={"text"}
-                name={FORM_FIELD_NAMES.ADDRESS}
-                placeholder={"주소를 입력하세요."}
-                value={signForm.address}
-                onChange={changeAddressHandler}
-              />
-              <Button color="l_blue" size="sm" text="주소 찾기" onClick={handleClick} />
-            </InputWrapper>
-          ) : (
-            <ContentValue>{dummy.myInfo.address}</ContentValue>
-          )}
+          <ContentValue>{myInfo.address}</ContentValue>
         </ContentSet>
-        {isEditing ? (
-          <>
-            <ContentSet>
-              <ContentKey>비밀번호</ContentKey>
-              <EditWrapper>
-                <InputWrapper className={`${error.password ? "error" : null}`}>
-                  <SignUpInput
-                    type={"password"}
-                    name={FORM_FIELD_NAMES.PASSWORD}
-                    placeholder={"현재 비밀번호를 입력하세요."}
-                    value={signForm.password}
-                    onChange={changeNowPasswordHandler}
-                  />
-                </InputWrapper>
-                <AlertMsg className={`${error.password ? "error" : ""}`}>
-                  <AiOutlineExclamationCircle />
-                  비밀번호가 일치하지 않습니다.
-                </AlertMsg>
-              </EditWrapper>
-            </ContentSet>
-            <ContentSet>
-              <ContentKey></ContentKey>
-              <EditWrapper>
-                <InputWrapper className={`${error.newPassword ? "error" : null}`}>
-                  <SignUpInput
-                    type={"password"}
-                    name={FORM_FIELD_NAMES.NEWPASSWORD}
-                    placeholder={"새 비밀번호를 입력하세요."}
-                    value={signForm.newPassword}
-                    onChange={changeNewPasswordHandler}
-                  />
-                </InputWrapper>
-                <AlertMsg className={`${error.newPassword ? "error" : null}`}>
-                  <AiOutlineExclamationCircle aria-hidden="true" />
-                  문자 숫자 특수문자 조합 8자 이상으로 조합해주세요.
-                </AlertMsg>
-              </EditWrapper>
-            </ContentSet>
-            <ContentSet>
-              <ContentKey></ContentKey>
-              <EditWrapper>
-                <InputWrapper className={`${error.confirmNewPassword ? "error" : null}`}>
-                  <SignUpInput
-                    type={"password"}
-                    name={FORM_FIELD_NAMES.CONFIRMNEWPASSWORD}
-                    placeholder={"새 비밀번호를 한번 더 입력하세요."}
-                    value={signForm.confirmNewPassword}
-                    onChange={changeNewConfirmPasswordHandler}
-                  />
-                </InputWrapper>
-                <AlertMsg className={`${error.confirmNewPassword ? "error" : null}`}>
-                  <AiOutlineExclamationCircle aria-hidden="true" />새 비밀번호와 일치하지 않습니다.
-                </AlertMsg>
-              </EditWrapper>
-            </ContentSet>
-          </>
-        ) : (
-          ""
-        )}
-        <ButtonContainer id="edit">
-          {isEditing ? null : (
-            <Button type={"button"} text="수정하기" color="blue" size="lg" onClick={() => setIsEditing(true)} />
-          )}
-        </ButtonContainer>
-        <ButtonContainer id="done">
-          {isEditing ? <Button type={"submit"} text="수정완료" color="blue" size="lg" /> : null}
-        </ButtonContainer>
       </Content>
     </Wrapper>
   );
@@ -325,39 +115,7 @@ const ImgContainer = styled.aside`
   align-items: center;
   width: 120px;
 `;
-const AlertMsg = styled.div`
-  display: none;
-  &.error {
-    display: block;
-    line-height: 0;
-    display: flex;
-    align-items: center;
-    font-weight: normal;
-    gap: 5px;
-    font-size: 15px;
-    color: var(--red);
-  }
-`;
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 10px;
-  #edit {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-  }
-  #done {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    @media (max-width: 768px) {
-      position: static;
-      display: flex;
-      padding-top: 20px;
-    }
-  }
-`;
+
 const ContentSet = styled.h3`
   display: flex;
   align-items: center;
@@ -379,41 +137,7 @@ const ContentValue = styled.span`
   font-size: 18px;
   color: var(--black-700);
 `;
-const EditWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-`;
-const InputWrapper = styled.span`
-  display: flex;
-  align-items: center;
-  padding-right: 3px;
-  height: 30px;
-  width: 400px;
-  input {
-    height: 25px;
-    padding-top: 2px;
-    font-size: 18px;
-    color: var(--black-700);
-    ::placeholder {
-      color: var(--black-200);
-    }
-  }
-  font-weight: normal;
-  border-radius: 5px;
-  border: 1px solid var(--black-150);
-  &:focus-within {
-    box-shadow: var(--wrapped-shadow);
-  }
-  &.error:focus-within {
-    box-shadow: var(--wrapped-shadow-red);
-    border: 1px solid hsl(359, 46%, 66%);
-    transition: 0.2s;
-  }
-  @media (max-width: 768px) {
-    width: 350px;
-  }
-`;
+
 const ReviewImgInput = styled.input`
   position: absolute;
   display: none;

--- a/front/src/Pages/Pharm/Pharmacy_Information.tsx
+++ b/front/src/Pages/Pharm/Pharmacy_Information.tsx
@@ -13,6 +13,7 @@ export default function PharmacyInformation() {
   const [pharmDetail, setPharmDetail]: any = useState();
   const [isModalUp, setIsModalUp] = useState(false);
   const [like, setLike] = useState(false);
+  const [reviewList, setReviewList] = useState([]);
   const [isDropDownDown, setIsDropDownDown] = useState(false);
   const [imageSrc, setImageSrc] = useState<string | ArrayBuffer | null>(null);
   const onUpload = (e: any) => {
@@ -31,11 +32,8 @@ export default function PharmacyInformation() {
   useEffect(() => {
     const getPharmDetail = async () => {
       try {
-        //* dummy data 일때 -> Pharm.json
-        // const response = await axios.get(API_PharmacyInformation.DUMMY_API);
-        //TODO 실제 url 일때 -> /api/store/{storeIdx}
         //? storeIdx 는 약사 계정으로 로그인 시 리덕스 툴킷에서 받아올 수 있음 일단 임의로 2
-        const response = await axios.get(`${API_PharmacyInformation.REAL_API}/store${2}`);
+        const response = await axios.get(`${API_PharmacyInformation.REAL_API}/store/${2}`);
         setPharmDetail(response.data);
       } catch (error) {
         console.log(error);
@@ -43,16 +41,40 @@ export default function PharmacyInformation() {
     };
     getPharmDetail();
   }, []);
+  //! GET : 약국상세정보 + 리뷰리스트
+  const onModalUp = () => {
+    const pharmDetailsAndreviewList = async () => {
+      await axios
+        //? storeIdx 는 약사 계정으로 로그인 시 리덕스 툴킷에서 받아올 수 있음 일단 임의로 2
+        .get(`${API_PharmacyInformation.REAL_API}/${2}`)
+        .then((response) => {
+          setPharmDetail(response.data.response);
+          axios
+            .get(`${API_PharmacyInformation.REAL_API}/${2}/review`)
+            .then((response) => {
+              setReviewList(response.data.response.storeReviews);
+            })
+            .catch((err) => console.log("리뷰받아오던 중" + err));
+        })
+        .catch((err) => console.log("약국상세받아오던 중" + err));
+    };
+    pharmDetailsAndreviewList();
+    setIsModalUp(true);
+  };
 
   return (
     <Content>
-      //* dummy data 일때
-      {/* {isModalUp ? (
-        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} pharmDetail={pharmDetail} />
-      ) : null} */}
-      //TODO 실제 url 일때
       {isModalUp ? (
-        <PharmDetail setIsModalUp={setIsModalUp} like={like} setLike={setLike} storeIdx={pharmDetail.storeIdx} Pharm={pharmDetail}/>
+        <PharmDetail
+          setIsModalUp={setIsModalUp}
+          like={like}
+          setLike={setLike}
+          //? storeIdx 는 약사 계정으로 로그인 시 리덕스 툴킷에서 받아올 수 있음 일단 임의로 2
+          storeIdx={2}
+          pharmDetail={pharmDetail}
+          reviewList={reviewList}
+          setReviewList={setReviewList}
+        />
       ) : null}
       <ImgContainer>
         <ImgInput id="pharmImg" type="file" onChange={(e) => onUpload(e)} accept="image/*" />
@@ -68,7 +90,7 @@ export default function PharmacyInformation() {
       </ImgContainer>
       <InfomationContainer>
         <Header>
-          <PharmName onClick={() => setIsModalUp(!isModalUp)}>킹갓약국</PharmName>
+          <PharmName onClick={() => onModalUp()}>킹갓약국</PharmName>
           <PharmRank
             rating={pharmDetail.rating}
             likes={pharmDetail.pickedStoreCount}

--- a/front/src/Pages/SignUp.tsx
+++ b/front/src/Pages/SignUp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 import PharmSignForms from "../Components/SignUpForm/PharmSignForms";
 import SignUpFormTab from "../Components/SignUpForm/SignUpFormTab";

--- a/front/src/Pages/User/MyInfo_Information.tsx
+++ b/front/src/Pages/User/MyInfo_Information.tsx
@@ -13,34 +13,21 @@ import { validators } from "../../Components/SignUpForm/Validation";
 interface Props {
   scriptUrl?: string;
 }
-interface SignFormProps {
-  name: string;
-  password: string;
-  newPassword: string;
-  confirmNewPassword: string;
-  address: string;
-}
 
 export default function MyInfoInformation({ scriptUrl }: Props) {
-  //데이터
-  const [myInfo, setMyInfo] = useState({
-    userIdx: 0,
+  const [myInfo, setMyInfo]: any = useState({
     createdAt: "",
     name: "",
-    password: "",
     email: "",
     address: "",
   });
+  const [imgFile, setImgFlie]: any = useState(null);
   const [myName, setMyName] = useState("");
-  // const [myPassword, setMyPassword] = useState(myInfo.password)
   const [myAddress, setMyAddress] = useState("");
-
   //! GET : 유저 정보
   useEffect(() => {
     const getReviews = async () => {
       try {
-        //* dummy data 일때 -> Review.json
-        // const response = await axios.get(API_MyInfoInformation.DUMMY_API);
         //TODO 실제 url 일때 -> /api/users/{userIdx}
         //? userIdx 는 리덕스 툴킷에서 -> 1
         const response = await axios.get(`${API_MyInfoInformation.REAL_API}/${1}`);
@@ -54,10 +41,10 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     getReviews();
   }, []);
 
-  //이미지를 미리보기
   const [imageSrc, setImageSrc] = useState<string | ArrayBuffer | null>(null);
   const onUpload = (e: any) => {
     const file = e.target.files[0];
+    setImgFlie(file);
     const reader = new FileReader();
     reader.readAsDataURL(file);
     return new Promise<void>((resolve) => {
@@ -70,8 +57,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
 
   const [isEditing, setIsEditing] = useState(false);
 
-  //유효성검사
-  const [signForm, setSignForms] = useState<SignFormProps>({
+  const [signForm, setSignForms] = useState({
     name: myInfo.name,
     password: "",
     newPassword: "",
@@ -119,7 +105,6 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     });
   };
 
-  //현재비밀번호
   const changeNowPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setSignForms({
@@ -128,7 +113,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     });
     let errors;
     if (name === FORM_FIELD_NAMES.PASSWORD) {
-      errors = validators.validatePasswordCheck(myInfo.password, value);
+      errors = validators.validatePassword(value);
     }
     setError({
       ...error,
@@ -136,13 +121,13 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     });
   };
 
-  //새비밀번호
   const changeNewPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setSignForms({
       ...signForm,
       [name]: value,
     });
+
     let errors;
     if (name === FORM_FIELD_NAMES.NEWPASSWORD) {
       errors = validators.validatePassword(value);
@@ -154,7 +139,6 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     });
   };
 
-  //새비밀번호 체크
   const changeNewConfirmPasswordHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setSignForms({
@@ -176,7 +160,6 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
   const handleComplete = (data: any) => {
     let fullAddress = data.address;
     let extraAddress = "";
-
     if (data.addressType === "R") {
       if (data.bname !== "") {
         extraAddress += data.bname;
@@ -186,10 +169,9 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
       }
       fullAddress += extraAddress !== "" ? ` (${extraAddress})` : "";
     }
-
-    setSignForms((prev) => ({ ...prev, [FORM_FIELD_NAMES.ADDRESS]: fullAddress }));
+    setSignForms((prev) => ({ ...prev, address: fullAddress }));
+    setMyAddress(fullAddress);
   };
-
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     open({ onComplete: handleComplete });
     e.preventDefault();
@@ -219,19 +201,79 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
     if (newPassword !== confirmNewPassword) {
       return alert("새 비밀번호를 한번 더 입력해주세요");
     }
+
+    const newUserData = {
+      name: name,
+      address: address,
+      password: password,
+      newPassword: newPassword,
+    };
+    const submitNewUserInfo: any = async () => {
+      try {
+        //? 수정 /api/users/{userIdx}=>리덕스에서 userIdx꺼내
+        await axios({
+          url: `${API_MyInfoInformation.REAL_API}/${1}`,
+          method: "patch",
+          data: newUserData,
+        }).then(() => setIsEditing(false));
+      } catch (err: any) {
+        if (err.response.status === 406) {
+          alert("현재비밀번호가 가입시 비밀번호와 다릅니다");
+        }
+      }
+    };
+    setMyInfo({ ...myInfo, ...newUserData });
+    submitNewUserInfo();
+  };
+
+  const submitUserImg = (e: any) => {
+    e.preventDefault();
+    const formDataImgsubmit = new FormData();
+    formDataImgsubmit.append("image", imgFile);
+
+    // TODO : 리덕스 툴킷에서 userIdx가져와 [JSON.stringify(userIdx)] 수정 => 아래주석 코드 지우면 안돼!
+    //   formDataForsubmit.append("userIdx", new Blob([JSON.stringify(userIdx)], { type: "application/json" }));
+    //
+
+    const submitNewImg: any = async () => {
+      try {
+        //? 수정 /api/users/{userIdx}=>리덕스에서 userIdx꺼내
+        await axios({
+          //TODO : {userIdx}/image 수정
+          url: `${API_MyInfoInformation.REAL_API}/${1}/image`,
+          method: "patch",
+          data: formDataImgsubmit,
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    submitNewImg();
   };
 
   return (
     <Wrapper onSubmit={onSubmit}>
       <ImgContainer>
-        <ReviewImgInput id="img" type="file" onChange={(e) => onUpload(e)} accept="image/*"></ReviewImgInput>
+        <ReviewImgInput
+          name="reviewImg"
+          id="img"
+          type="file"
+          onChange={(e) => onUpload(e)}
+          accept="image/*"
+        ></ReviewImgInput>
         {imageSrc ? <ReviewImg src={imageSrc as string} /> : <ReviewImg src="Images/User.png" alt="user" />}
-        <Label htmlFor="img">
-          <MdOutlineAddAPhoto aria-hidden="true" />
-          사진추가하기
-        </Label>
+        {imageSrc ? (
+          <Label onClick={submitUserImg}>
+            <MdOutlineAddAPhoto aria-hidden="true" />
+            사진수정완료
+          </Label>
+        ) : (
+          <Label htmlFor="img">
+            <MdOutlineAddAPhoto aria-hidden="true" />
+            사진수정하기
+          </Label>
+        )}
       </ImgContainer>
-
       <Content>
         <ContentSet>
           <ContentKey>가입일</ContentKey>
@@ -269,11 +311,11 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
           {isEditing ? (
             <InputWrapper>
               <SignUpInput
-                // readOnly
+                readOnly
                 type={"text"}
                 name={FORM_FIELD_NAMES.ADDRESS}
                 placeholder={"주소를 입력하세요."}
-                value={signForm[FORM_FIELD_NAMES.ADDRESS]}
+                value={myAddress}
                 onChange={changeAddressHandler}
               />
               <Button color="l_blue" size="sm" text="주소 찾기" onClick={handleClick} />
@@ -317,7 +359,7 @@ export default function MyInfoInformation({ scriptUrl }: Props) {
                 </InputWrapper>
                 <AlertMsg className={`${error.newPassword ? "error" : null}`}>
                   <AiOutlineExclamationCircle aria-hidden="true" />
-                  문자 숫자 특수문자 조합 8자 이상으로 조합해주세요.
+                  문자 숫자 특수문자 조합 8자 이상으로 조합으로 입력해주세요.
                 </AlertMsg>
               </EditWrapper>
             </ContentSet>
@@ -375,6 +417,7 @@ const AlertMsg = styled.div`
     color: var(--red);
   }
 `;
+
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/front/src/Pages/User/MyInfo_likes.tsx
+++ b/front/src/Pages/User/MyInfo_likes.tsx
@@ -3,28 +3,29 @@ import { Link } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
 import LikedPharmacyUnit from "../User/MyInfo_likedPharmacy";
-import { API_MyInfoLikes } from "../../Api/APIs";
+import { API_LikedPharmacyUnit } from "../../Api/APIs";
 import { IoMdAddCircleOutline } from "react-icons/io";
 
 export default function MyInfoLikes() {
   const [likedPharmacies, setLikedPharmacies] = useState([]);
 
-  //! GET : 내가 찜한 약국 리스트
-  useEffect(() => {
-    const getLikedPharmList = async () => {
-      try {
-        //* dummy url 일때
-        const response = await axios.get(API_MyInfoLikes.DUMMY_API);
-        //TODO url 받았을때 -> /api/users/{userIdx}/store
-        //? userIdx 는 리덕스 툴킷에서
-        // const response = await axios.get(`${API_MyInfoLikes.REAL_API}/${userIdx}/store`);
-        setLikedPharmacies(response.data);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    getLikedPharmList();
-  }, []);
+//! GET : 내가 찜한 약국 리스트
+useEffect(() => {
+  const getLikedPharmList = async () => {
+    try {
+      //TODO url 받았을때 -> /api/store/user/{userIdx}/pick
+      //! 이거 안돼 => 찜하기 데이터가 없어서 안뜸?
+      //? userIdx 는 리덕스 툴킷에서
+      const response = await axios.get(`${API_LikedPharmacyUnit.GET_REAL_API}/${1}/pick`);
+
+      setLikedPharmacies(response.data);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  getLikedPharmList();
+}, []);
+
 
   return (
     <Content>
@@ -38,7 +39,12 @@ export default function MyInfoLikes() {
       {likedPharmacies.length ? (
         <Rest>
           {likedPharmacies.map((likedPharmacy: any) => (
-            <LikedPharmacyUnit likedPharmacy={likedPharmacy} />
+            <LikedPharmacyUnit
+              key={likedPharmacy.storeIdx}
+              likedPharmacy={likedPharmacy}
+              likedPharmacies={likedPharmacies}
+              setLikedPharmacies={setLikedPharmacies}
+            />
           ))}
         </Rest>
       ) : (

--- a/front/src/Pages/User/MyInfo_reviews.tsx
+++ b/front/src/Pages/User/MyInfo_reviews.tsx
@@ -13,9 +13,6 @@ export default function MyInfoReviews() {
   useEffect(() => {
     const getMyReviews = async () => {
       try {
-        //* dummy data 일때 -> Review.json
-        // const response = await axios.get(API_MyPharmacy.DUMMY_API);
-        //TODO 실제 url 일때 -> /api/users/{userIdx}/review
         //? userIdx 는 리덕스 툴킷에서 가져오고 일단은 임의로 1
         const response = await axios.get(`${API_MyPharmacy.REAL_API}/${1}/review`);
         setReviews(response.data);

--- a/front/src/hooks/useMap.ts
+++ b/front/src/hooks/useMap.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import useGeolocation from "./useGeolocation";
 import "./PharmacyOverlay.css";
-// import { API_PharmLists } from "../Api/APIs";
 
 const { kakao } = window;
 
@@ -14,10 +13,8 @@ interface Props {
 export function useMap(totalPharmList: any, setTotalPharmList: any) {
   const location: any = useGeolocation();
   const [_map, setMap]: any = useState();
-  // const [pharmacies, setPharmacies] = useState([]);
   const [mapCenter, setMapCenter] = useState({ latitude: 0, longitude: 0 });
-  const API_URL = "https://apis.data.go.kr/B552657";
-  // const API_URL = API_PharmLists.REAL_API;
+
 
   useEffect(() => {
     if (typeof location != "string" && kakao) {


### PR DESCRIPTION
### 1. CRUD 구현

**기본기능**
- 지도 기능 (이후 영재님 PR merge 예정) 
- 약국 전체/심야/영업중 약국 필터링 기능 (영재)
- 약국 가까운순/리뷰많은순/별점순 정렬 (영재)
- 약국 상세정보 조회
- 약국 리뷰 조회/작성/수정/삭제/신고
- 약국 리뷰의 댓글 조회/작성/수정/삭제

**일반계정**
- 내 정보 조회 (성은)
- 내 정보 수정 (성은)
- 찜한 약국 리스트 조회
- 찜한 약국 삭제 : 찜취소 
- 내가 남긴리뷰 조회
- 내가 남긴리뷰 삭제 

**약사계정**
- 내 정보 조회 (성은)
- 내 이미지 업로드 (성은)
- 내 약국정보 조회 (성은)
- 내 약국 이미지 업로드 (성은)

**관리자계정**
- 약사인증신청 리스트 조회
- 약사인증신청 승인
- 약사인증신청 반려
- 전체회원 리스트 조회
- 선택 계정 정지 (옵션 기간동안)
- 선택 계정 강퇴
- 신고 리뷰 조회
- 신고 리뷰 삭제 
- (블라인드 처리 된) 신고 리뷰 복구

### 2. get 요청 위치 변경

**너무 많은 양의 정보 요청으로 모달창 팝업시 약국의 상세정보 및 리뷰 리스트를 get 해오도록 수정하였습니다**