### PR TITLE
Be_feat/S3 버킷 연동

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -59,8 +59,11 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 
 	implementation group: 'com.google.code.geocoder-java', name: 'geocoder-java', version: '0.16'//위치정보
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // S3 이미지 업로드
+
+	// S3 이미지 업로드
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
+
 
 tasks.named('test') {
 	outputs.dir snippetsDir

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 
 	implementation group: 'com.google.code.geocoder-java', name: 'geocoder-java', version: '0.16'//위치정보
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // S3 이미지 업로드
 }
 
 tasks.named('test') {

--- a/back/src/main/java/com/project/mainproject/MainprojectApplication.java
+++ b/back/src/main/java/com/project/mainproject/MainprojectApplication.java
@@ -11,6 +11,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 import java.util.UUID;
 
+//@SpringBootApplication(
+//		exclude = {
+//				org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration.class,
+//				org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration.class,
+//				org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration.class
+//		}
+//)
 @SpringBootApplication
 @EnableJpaAuditing
 public class MainprojectApplication {

--- a/back/src/main/java/com/project/mainproject/config/S3Config.java
+++ b/back/src/main/java/com/project/mainproject/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.project.mainproject.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/back/src/main/java/com/project/mainproject/review/service/ReviewService.java
+++ b/back/src/main/java/com/project/mainproject/review/service/ReviewService.java
@@ -28,6 +28,7 @@ import static com.project.mainproject.review.exception.ReviewExceptionCode.REVIE
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final FileUploader fileUploader;
 
     public Page<Review> getReviews(Long storeIdx, Pageable pageable) {
         // TODO: 존재하는 약국 검증 추가 (StoreService)
@@ -98,7 +99,7 @@ public class ReviewService {
     }
 
     private String uploadImage(MultipartFile image) {
-        return FileUploader.saveImage(image);
+        return fileUploader.saveImage(image, "review");
     }
 
     public List<Review> getUserReviews(Long userIdx) {

--- a/back/src/main/java/com/project/mainproject/review/service/ReviewService.java
+++ b/back/src/main/java/com/project/mainproject/review/service/ReviewService.java
@@ -80,7 +80,11 @@ public class ReviewService {
     @Transactional
     public void deleteReview(Long storeIdx, Long reviewIdx) {
         Review review = findVerifiedReview(storeIdx, reviewIdx);
-        reviewRepository.delete(review);
+        review.setReviewStatus(DELETED);
+
+        if (review.getReviewImages().size() != 0)
+            fileUploader.deleteS3Image(review.getReviewImages().get(0).getImagePath());
+        review.deleteReviewImage();
     }
 
     public Review findVerifiedReview(Long storeIdx, Long reviewIdx) {

--- a/back/src/main/java/com/project/mainproject/store/service/StoreService.java
+++ b/back/src/main/java/com/project/mainproject/store/service/StoreService.java
@@ -25,6 +25,7 @@ public class StoreService {
     private final StoreQueryRepository storeQueryRepository;
     private final PickedStoreRepository pickedStoreRepository;
     private final UserService userService;
+    private final FileUploader fileUploader;
 
     public SingleResponseDto pickStore(Long userIdx, Long storeIdx) {
         Normal findUser = (Normal) userService.validUser(userIdx);    //user 가 존재하는지 먼저 검증 시큐리티 적용 후 필요 없음
@@ -69,10 +70,10 @@ public class StoreService {
         StoreImage storeImages = pharmacy.getStore().getStoreImages();
         String uploadImagePath = null;
         if (storeImages == null) {
-            uploadImagePath = FileUploader.saveImage(multipartFile);
+            uploadImagePath = fileUploader.saveImage(multipartFile);
         } else {
             String deleteImagePath = storeImages.getImagePath();
-            uploadImagePath = FileUploader.deleteAndSaveImage(multipartFile, deleteImagePath);
+            uploadImagePath = fileUploader.deleteAndSaveImage(multipartFile, deleteImagePath);
         }
 
         StoreImage storeImage = StoreImage.builder().imagePath(uploadImagePath).store(pharmacy.getStore()).build();

--- a/back/src/main/java/com/project/mainproject/utils/FileUploader.java
+++ b/back/src/main/java/com/project/mainproject/utils/FileUploader.java
@@ -1,6 +1,13 @@
 package com.project.mainproject.utils;
 
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -9,15 +16,18 @@ import java.util.List;
 import java.util.UUID;
 
 @Slf4j
+@RequiredArgsConstructor
+@Component
 public class FileUploader {
 
-//    @Value("${upload.path}")
-//    private String uploadPath;
-    private final static String uploadDir = "C:/study/file/";
+    private final AmazonS3Client amazonS3Client;
+    private final String UPLOAD_PATH = "";
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
 
-    public static String saveImage(MultipartFile uploadFile) {
+    public String saveImage(MultipartFile uploadFile) {
         String fileName = createFileName(uploadFile.getOriginalFilename());
-        String uploadFilePath = uploadDir + fileName;
+        String uploadFilePath = UPLOAD_PATH + fileName;
         try {
             uploadFile.transferTo(new File(uploadFilePath));
         } catch (IOException e) {
@@ -26,20 +36,46 @@ public class FileUploader {
         return uploadFilePath;
     }
 
-    private static String createFileName(String originalFilename) {
+    public String saveImage(MultipartFile uploadFile, String uploadDir) {
+        String fileName = uploadDir + "/" + createFileName(uploadFile.getOriginalFilename());
+        ObjectMetadata metadata = createMetadata(uploadFile);
+
+        try {
+            amazonS3Client.putObject(
+                    new PutObjectRequest(
+                            bucketName, fileName, uploadFile.getInputStream(), metadata
+                    ).withCannedAcl(CannedAccessControlList.PublicRead)
+            );
+        }catch (IOException e) {
+            log.error("#### Save Image IOException", e.getMessage());
+            e.printStackTrace();
+        }
+
+        return amazonS3Client.getUrl(bucketName, fileName).toString();
+    }
+
+    private ObjectMetadata createMetadata(MultipartFile multipartFile) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(multipartFile.getContentType());
+        metadata.setContentLength(multipartFile.getSize());
+
+        return metadata;
+    }
+
+    private String createFileName(String originalFilename) {
         String uuid = UUID.randomUUID().toString();
         String ext = extractExt(originalFilename);
 
         return uuid.concat(ext);
     }
 
-    private static String extractExt(String originalFilename) {
+    private String extractExt(String originalFilename) {
         int idx = originalFilename.lastIndexOf(".");
 
         return originalFilename.substring(idx);
     }
     
-    public static void deleteImages(List<String> imagePaths) {
+    public void deleteImages(List<String> imagePaths) {
         boolean isSuccess = false;
         for (String imagePath : imagePaths) {
             File deleteFile = new File(imagePath);
@@ -47,7 +83,7 @@ public class FileUploader {
             if (!isSuccess) throw new RuntimeException("파일 삭제 실패");
         }
     }
-    public static void deleteImage(String imagePath) {
+    public void deleteImage(String imagePath) {
         File deleteFile = new File(imagePath);
         if (!deleteFile.delete()) {
             throw new RuntimeException("파일 삭제 실패");
@@ -55,7 +91,7 @@ public class FileUploader {
 
     }
 
-    public static String deleteAndSaveImage(MultipartFile uploadFile , String imagePath) {
+    public String deleteAndSaveImage(MultipartFile uploadFile , String imagePath) {
         deleteImage(imagePath);
         String uploadFilePath = saveImage(uploadFile);
         return uploadFilePath;

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -1,3 +1,13 @@
 spring:
   profiles:
     active: ${profile}
+
+cloud:
+  aws:
+    s3:
+      bucket: main-005-image
+    stack.auto: false
+    region.static: ap-northeast-2
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_SECRET_KEY}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -1,7 +1,10 @@
 spring:
   profiles:
     active: ${profile}
-
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 cloud:
   aws:
     s3:


### PR DESCRIPTION
- 기존 사용되는 코드에 지장 없도록 오버로딩 / 추가되어있습니다
 (전부 연동 후에 삭제 예정)
- 현재 연동 현황 [리뷰]
  + 리뷰 등록 시 버킷/review/에 업로드
  + 리뷰 삭제 시 S3 객체 삭제, DB 이미지 데이터 삭제, Reivew Status 변경 (POSTED -> DELETED)
- FileUploader.saveImage() 사용 시 ❗ multifile과 이미지가 저장될 폴더 명을 함께 보내주시면 저장 경로가 return 됩니다
  + ex) fileUploader.saveImage(image, "review") ==> return "https://main-005-image.s3.ap-northeast-2.amazonaws.com/review/4d956d92-0af8-446c-86ef-38c1fa155b05.jpg"